### PR TITLE
Secure routes with write access to database

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,21 +1,20 @@
 """Initialize the Flask app and register all routes."""
 
 import os
-
-from dotenv import load_dotenv
 from flask import Flask
+from app.config import Config
 
-
-def create_app():
+def create_app(test_config=None):
     """Application factory pattern."""
-    # Load the env variables to use here
-    load_dotenv()
 
     app = Flask(__name__)
-    # Use app.config to set config connection details
-    app.config["MONGO_URI"] = os.getenv("MONGO_CONNECTION")
-    app.config["DB_NAME"] = os.getenv("PROJECT_DATABASE")
-    app.config["COLLECTION_NAME"] = os.getenv("PROJECT_COLLECTION")
+
+    if test_config is None:
+        # Load configuration from our Config object
+        app.config.from_object(Config)
+    else:
+        # Load the test configuration passed in
+        app.config.from_mapping(test_config)
 
     # Import routes — routes can import app safely because it exists
     from app.routes import \

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -9,14 +9,13 @@ def create_app(test_config=None):
 
     app = Flask(__name__)
 
-    if test_config is None:
-        # Load configuration from our Config object
-        app.config.from_object(Config)
-    else:
-        # Load the test configuration passed in
+    # 1. Load the default configuration from the Config object.
+    app.config.from_object(Config)
+
+    if test_config: # Override with test specifics
         app.config.from_mapping(test_config)
 
-    # Import routes — routes can import app safely because it exists
+    # Import routes
     from app.routes import \
         register_routes  # pylint: disable=import-outside-toplevel
 

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,8 +1,11 @@
 """Initialize the Flask app and register all routes."""
 
 import os
+
 from flask import Flask
+
 from app.config import Config
+
 
 def create_app(test_config=None):
     """Application factory pattern."""
@@ -12,7 +15,7 @@ def create_app(test_config=None):
     # 1. Load the default configuration from the Config object.
     app.config.from_object(Config)
 
-    if test_config: # Override with test specifics
+    if test_config:  # Override with test specifics
         app.config.from_mapping(test_config)
 
     # Import routes

--- a/app/config.py
+++ b/app/config.py
@@ -8,22 +8,24 @@ used to configure Flask and database connection settings.
 """
 
 import os
+
 from dotenv import load_dotenv
 
 # Find the absolute path of the root directory of the project
 basedir = os.path.abspath(os.path.dirname(__file__))
 # Build the path to the .env file located in the parent directory of the project root
-dotenv_path = os.path.join(os.path.dirname(basedir), '.env')
+dotenv_path = os.path.join(os.path.dirname(basedir), ".env")
 # Load environment variables to be used
 load_dotenv(dotenv_path=dotenv_path)
 
+
 class Config:
-    """ Set Flask configuration variables from environment variables"""
+    """Set Flask configuration variables from environment variables"""
 
     # General config
-    SECRET_KEY = os.environ.get('SECRET_KEY')
-    FLASK_APP = os.environ.get('FLASK_APP')
-    FLASK_ENV = os.environ.get('FLASK') # values will be 'development' or 'production'
+    SECRET_KEY = os.environ.get("SECRET_KEY")
+    FLASK_APP = os.environ.get("FLASK_APP")
+    FLASK_ENV = os.environ.get("FLASK")  # values will be 'development' or 'production'
     API_KEY = os.environ.get("API_KEY")
 
     # Database config

--- a/app/config.py
+++ b/app/config.py
@@ -12,8 +12,10 @@ from dotenv import load_dotenv
 
 # Find the absolute path of the root directory of the project
 basedir = os.path.abspath(os.path.dirname(__file__))
+# Build the path to the .env file located in the parent directory of the project root
+dotenv_path = os.path.join(os.path.dirname(basedir), '.env')
 # Load environment variables to be used
-load_dotenv(os.path.join(basedir, '.env'))
+load_dotenv(dotenv_path=dotenv_path)
 
 class Config:
     """ Set Flask configuration variables from environment variables"""
@@ -22,6 +24,7 @@ class Config:
     SECRET_KEY = os.environ.get('SECRET_KEY')
     FLASK_APP = os.environ.get('FLASK_APP')
     FLASK_ENV = os.environ.get('FLASK') # values will be 'development' or 'production'
+    API_KEY = os.environ.get("API_KEY")
 
     # Database config
     MONGO_URI = os.environ.get("MONGO_CONNECTION")

--- a/app/config.py
+++ b/app/config.py
@@ -1,0 +1,29 @@
+# pylint: disable=too-few-public-methods
+
+"""
+Application configuration module for Flask.
+
+Loads environment variables from a .env file and defines the Config class
+used to configure Flask and database connection settings.
+"""
+
+import os
+from dotenv import load_dotenv
+
+# Find the absolute path of the root directory of the project
+basedir = os.path.abspath(os.path.dirname(__file__))
+# Load environment variables to be used
+load_dotenv(os.path.join(basedir, '.env'))
+
+class Config:
+    """ Set Flask configuration variables from environment variables"""
+
+    # General config
+    SECRET_KEY = os.environ.get('SECRET_KEY')
+    FLASK_APP = os.environ.get('FLASK_APP')
+    FLASK_ENV = os.environ.get('FLASK') # values will be 'development' or 'production'
+
+    # Database config
+    MONGO_URI = os.environ.get("MONGO_CONNECTION")
+    DB_NAME = os.environ.get("PROJECT_DATABASE")
+    COLLECTION_NAME = os.environ.get("PROJECT_COLLECTION")

--- a/app/routes.py
+++ b/app/routes.py
@@ -4,10 +4,11 @@ import copy
 import uuid
 
 from flask import jsonify, request
-from werkzeug.exceptions import NotFound
+from werkzeug.exceptions import NotFound, HTTPException
 
 from app.datastore.mongo_db import get_book_collection
 from app.datastore.mongo_helper import insert_book_to_mongo
+from app.utils.api_security import require_api_key
 from app.utils.helper import append_hostname
 from data import books
 
@@ -21,6 +22,7 @@ def register_routes(app):  # pylint: disable=too-many-statements
     """
 # ----------- POST section ------------------
     @app.route("/books", methods=["POST"])
+    @require_api_key
     def add_book():
         """Function to add a new book to the collection."""
         # check if request is json
@@ -218,6 +220,22 @@ def register_routes(app):  # pylint: disable=too-many-statements
     def handle_not_found(e):
         """Return a custom JSON response for 404 Not Found errors."""
         return jsonify({"error": str(e)}), 404
+    @app.errorhandler(HTTPException)
+
+    def handle_http_exception(e):
+        """
+        Return JSON for any HTTPException (401, 404, 403, etc.)
+        preserving its original status code & description.
+        """
+        # e.code is the HTTP status code (e.g. 401)
+        # e.description is the text you passed to abort()
+        response = {
+        "error": {
+            "code":    e.code,
+            "message": e.description
+        }
+        }
+        return jsonify(response), e.code
 
     @app.errorhandler(Exception)
     def handle_exception(e):

--- a/app/routes.py
+++ b/app/routes.py
@@ -12,7 +12,6 @@ from app.utils.helper import append_hostname
 from data import books
 
 
-# ----------- POST section ------------------
 def register_routes(app):  # pylint: disable=too-many-statements
     """
     Register all Flask routes with the given app instance.
@@ -20,7 +19,7 @@ def register_routes(app):  # pylint: disable=too-many-statements
     Args:
         app (Flask): The Flask application instance to register routes on.
     """
-
+# ----------- POST section ------------------
     @app.route("/books", methods=["POST"])
     def add_book():
         """Function to add a new book to the collection."""

--- a/app/routes.py
+++ b/app/routes.py
@@ -151,6 +151,7 @@ def register_routes(app):  # pylint: disable=too-many-statements
 
     # ----------- DELETE section ------------------
     @app.route("/books/<string:book_id>", methods=["DELETE"])
+    @require_api_key
     def delete_book(book_id):
         """
         Soft delete a book by setting its state to 'deleted' or return error if not found.

--- a/app/routes.py
+++ b/app/routes.py
@@ -4,7 +4,7 @@ import copy
 import uuid
 
 from flask import jsonify, request
-from werkzeug.exceptions import NotFound, HTTPException
+from werkzeug.exceptions import HTTPException, NotFound
 
 from app.datastore.mongo_db import get_book_collection
 from app.datastore.mongo_helper import insert_book_to_mongo
@@ -20,7 +20,8 @@ def register_routes(app):  # pylint: disable=too-many-statements
     Args:
         app (Flask): The Flask application instance to register routes on.
     """
-# ----------- POST section ------------------
+
+    # ----------- POST section ------------------
     @app.route("/books", methods=["POST"])
     @require_api_key
     def add_book():
@@ -220,8 +221,8 @@ def register_routes(app):  # pylint: disable=too-many-statements
     def handle_not_found(e):
         """Return a custom JSON response for 404 Not Found errors."""
         return jsonify({"error": str(e)}), 404
-    @app.errorhandler(HTTPException)
 
+    @app.errorhandler(HTTPException)
     def handle_http_exception(e):
         """
         Return JSON for any HTTPException (401, 404, 403, etc.)
@@ -229,12 +230,7 @@ def register_routes(app):  # pylint: disable=too-many-statements
         """
         # e.code is the HTTP status code (e.g. 401)
         # e.description is the text you passed to abort()
-        response = {
-        "error": {
-            "code":    e.code,
-            "message": e.description
-        }
-        }
+        response = {"error": {"code": e.code, "message": e.description}}
         return jsonify(response), e.code
 
     @app.errorhandler(Exception)

--- a/app/routes.py
+++ b/app/routes.py
@@ -167,6 +167,7 @@ def register_routes(app):  # pylint: disable=too-many-statements
     # ----------- PUT section ------------------
 
     @app.route("/books/<string:book_id>", methods=["PUT"])
+    @require_api_key
     def update_book(book_id):
         """
         Update a book by its unique ID using JSON from the request body.

--- a/app/routes.py
+++ b/app/routes.py
@@ -219,6 +219,9 @@ def register_routes(app):  # pylint: disable=too-many-statements
 
         return jsonify({"error": "Book not found"}), 404
 
+
+    # ----------- CUSTOM ERROR HANDLERS ------------------
+
     @app.errorhandler(NotFound)
     def handle_not_found(e):
         """Return a custom JSON response for 404 Not Found errors."""
@@ -226,13 +229,18 @@ def register_routes(app):  # pylint: disable=too-many-statements
 
     @app.errorhandler(HTTPException)
     def handle_http_exception(e):
-        """
-        Return JSON for any HTTPException (401, 404, 403, etc.)
+        """Return JSON for any HTTPException (401, 404, 403, etc.)
         preserving its original status code & description.
         """
         # e.code is the HTTP status code (e.g. 401)
         # e.description is the text you passed to abort()
-        response = {"error": {"code": e.code, "message": e.description}}
+        response = {
+            "error": {
+                "code": e.code,
+                "name": e.name,
+                "message": e.description
+            }
+        }
         return jsonify(response), e.code
 
     @app.errorhandler(Exception)

--- a/app/utils/api_security.py
+++ b/app/utils/api_security.py
@@ -1,0 +1,23 @@
+"""API security decorators."""
+
+from functools import wraps
+from flask import request, abort, current_app
+
+def require_api_key(f):
+    """A decorator to protect routes with a required API key"""
+    @wraps(f)
+    def decorated_function(*args, **kwargs):
+        # Check for the key in the request headers.
+        provided_key = request.headers.get("X-API-KEY")
+        print("PROVIDED_KEY", provided_key)
+
+        # Get the real key from our application config
+        expected_key = current_app.config.get('API_KEY')
+        print("EXPECTED_KEY", expected_key)
+
+        if not provided_key or provided_key != expected_key:
+            abort(401, description="Invalid or missing API Key.")
+
+        # If key is valid, proceed with the original function
+        return f(*args, **kwargs)
+    return decorated_function

--- a/app/utils/api_security.py
+++ b/app/utils/api_security.py
@@ -1,10 +1,13 @@
 """API security decorators."""
 
 from functools import wraps
-from flask import request, abort, current_app
+
+from flask import abort, current_app, request
+
 
 def require_api_key(f):
     """A decorator to protect routes with a required API key"""
+
     @wraps(f)
     def decorated_function(*args, **kwargs):
         # Check for the key in the request headers.
@@ -12,7 +15,7 @@ def require_api_key(f):
         print("PROVIDED_KEY", provided_key)
 
         # Get the real key from our application config
-        expected_key = current_app.config.get('API_KEY')
+        expected_key = current_app.config.get("API_KEY")
         print("EXPECTED_KEY", expected_key)
 
         if not provided_key or provided_key != expected_key:
@@ -20,4 +23,5 @@ def require_api_key(f):
 
         # If key is valid, proceed with the original function
         return f(*args, **kwargs)
+
     return decorated_function

--- a/app/utils/api_security.py
+++ b/app/utils/api_security.py
@@ -1,7 +1,6 @@
 """API security decorators."""
-
+import hmac
 from functools import wraps
-
 from flask import abort, current_app, request
 
 
@@ -10,16 +9,22 @@ def require_api_key(f):
 
     @wraps(f)
     def decorated_function(*args, **kwargs):
-        # Check for the key in the request headers.
-        provided_key = request.headers.get("X-API-KEY")
-        print("PROVIDED_KEY", provided_key)
 
         # Get the real key from our application config
         expected_key = current_app.config.get("API_KEY")
         print("EXPECTED_KEY", expected_key)
+        if not expected_key:
+            abort(500, description="API key not configured on the server.")
 
-        if not provided_key or provided_key != expected_key:
-            abort(401, description="Invalid or missing API Key.")
+        # 2. Get the provided key from the request headers.
+        provided_key = request.headers.get("X-API-KEY")
+        if not provided_key:
+            abort(401, description="API key is missing.")
+
+        # 3. Securely compare the provided key with the expected key
+        # hmac.compare_digest is essential to prevent timing attacks
+        if not hmac.compare_digest(provided_key, expected_key):
+            abort(401, description="Invalid API key.")
 
         # If key is valid, proceed with the original function
         return f(*args, **kwargs)

--- a/app/utils/api_security.py
+++ b/app/utils/api_security.py
@@ -1,7 +1,10 @@
 """API security decorators."""
+
 import hmac
 from functools import wraps
+
 from flask import abort, current_app, request
+
 
 def log_unauthorized_access():
     """
@@ -10,6 +13,7 @@ def log_unauthorized_access():
     current_app.logger.warning(
         f"Unauthorized access attempt: IP={request.remote_addr}, path={request.path}"
     )
+
 
 def require_api_key(f):
     """A decorator to protect routes with a required API key"""

--- a/openapi.yml
+++ b/openapi.yml
@@ -6,12 +6,12 @@ info:
   title: Book Collection API
   version: v1.0.0
   description: A simple API to manage a collection of books.
-  termsOfService: 'https://github.com/methods/NandS_BookAPIV.2'
+  termsOfService: 'https://github.com/methods/S_BookAPIV.2'
   contact:
     email: booksAPI@example.com
   license:
     name: MIT License
-    url: 'https://github.com/methods/NandS_BookAPIV.2/blob/main/LICENSE.md'
+    url: 'https://github.com/methods/S_BookAPIV.2/blob/main/LICENSE.md'
 
 # --------------------------------------------
 # Server
@@ -31,6 +31,12 @@ tags:
 # --------------------------------------------
 # Components
 components:
+  securitySchemes:
+    ApiKeyAuth:
+      type: apiKey
+      in: header
+      name: X-API-KEY
+  
   schemas:
     # Schema for the data client POSTs to create a book
     BookInput:
@@ -105,14 +111,63 @@ components:
             $ref: '#/components/schemas/BookOutput'
 
     # Generic Error schema
-    Error:
+    StandardError:
       type: object
       properties:
         error:
-          type: string
-          description: A message describing the error.
+          type: object
+          properties:
+            code:
+              type: integer
+              description: The HTTP status code.
+              example: 400
+            name:
+              type: string
+              description: The HTTP status name.
+              example: "Bad Request"
+            message:
+              type: string
+              description: A detailed error message.
+              example: "API key is missing."
+          required:
+            - code
+            - name
+            - message
       required:
         - error
+    
+  # API Error: Reusable responses for common errors  
+  responses:
+    BadRequest:
+      description: The server could not process the request due to a client error (e.g., malformed request syntax, invalid request message framing, or deceptive request routing).
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/StandardError'
+    Unauthorized:
+      description: API key is missing or invalid.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/StandardError'
+    NotFound:
+      description: The requested resource could not be found.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/StandardError'
+    UnsupportedMediaType:
+      description: The request payload is not in the expected format (e.g., not JSON).
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/StandardError'
+    InternalServerError:
+      description: An unexpected error occurred on the server.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/StandardError'
 # --------------------------------------------
 # Paths
 paths:
@@ -123,8 +178,10 @@ paths:
       tags:
         - Books
       summary: Add a new book
+      security:
+        - ApiKeyAuth: [] 
       description: Adds a new book to the collection. The server will generate a unique ID and HATEOAS links for the new book.
-      operationId: addBook 
+      operationId: addBook
       requestBody:
         description: Book object that needs to be added to the store.
         required: true
@@ -140,40 +197,13 @@ paths:
               schema:
                 $ref: '#/components/schemas/BookOutput' 
         '400': 
-          description: Invalid input provided or missing fields.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-              examples:
-                missingFields:
-                  summary: Example of missing fields error
-                  value:
-                    error: "Missing required fields: title, synopsis"
-                notADictionary:
-                  summary: Example of payload not being a dictionary
-                  value:
-                    error: "JSON payload must be a dictionary"
-                incorrectFieldTypeInternal:
-                  summary: Example of internal field type validation error 
-                  value:
-                    error: "Field title is not of type <class 'str'>"
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
         '415': 
-          description: Request payload is not JSON.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-              example:
-                error: "Request must be JSON"
+          $ref: '#/components/responses/UnsupportedMediaType'
         '500':
-          description: Internal Server Error. An unexpected error occurred on the server.
-          content:
-            application/json: 
-              schema:
-                $ref: '#/components/schemas/Error'
-              example:
-                error: "An unexpected error occurred."
+          $ref: '#/components/responses/InternalServerError' 
     # --------------------------------------------
     get:
       tags:
@@ -198,21 +228,9 @@ paths:
                     items:
                       $ref: '#/components/schemas/BookOutput'
         '404':
-          description: No books found in the database.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-              example:
-                error: "No books found"
+          $ref: '#/components/responses/NotFound' 
         '500':
-          description: Internal Server Error. An unexpected error occurred.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-              example:
-                error: "An unexpected error occurred."
+          $ref: '#/components/responses/InternalServerError' 
   # --------------------------------------------
   /books/{book_id}: 
   # --------------------------------------------
@@ -239,30 +257,17 @@ paths:
               schema:
                 $ref: '#/components/schemas/BookOutput' 
         '404': 
-          description: Book not found. The requested book ID does not exist.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error' 
-              example:
-                bookNotFound:
-                  summary: Example of a book not found error
-                  value:
-                    error: "Book not found"
+          $ref: '#/components/responses/NotFound' 
         '500': 
-          description: Internal Server Error. An unexpected error occurred on the server.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error' 
-              example: 
-                error: "An unexpected error occurred."
+          $ref: '#/components/responses/InternalServerError' 
      # --------------------------------------------
 
     put:
       tags:
         - Books
       summary: Update a book
+      security:
+        - ApiKeyAuth: []
       description: Updates an existing book by its unique ID. The entire book object must be provided in the request body.
       operationId: updateBook
       parameters:
@@ -289,50 +294,24 @@ paths:
               schema:
                 $ref: '#/components/schemas/BookOutput'
         '400':
-          description: Invalid input, or missing required fields.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-              examples:
-                missingFields:
-                  summary: Example of missing fields error
-                  value:
-                    error: "Missing required fields: title"
-                notADictionary:
-                  summary: Example of payload not being a dictionary
-                  value:
-                    error: "JSON payload must be a dictionary"
+          $ref: '#/components/responses/BadRequest' 
+        '401':
+          $ref: '#/components/responses/Unauthorized' 
         '404':
-          description: Book not found. The requested book ID does not exist.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-              example:
-                error: "Book not found"
+          $ref: '#/components/responses/NotFound' 
         '415':
-          description: Request payload is not JSON.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-              example:
-                error: "Request must be JSON"
+          $ref: '#/components/responses/UnsupportedMediaType' 
         '500':
-          description: Internal Server Error. An unexpected error occurred on the server.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-              example:
-                error: "Book collection not initialized"
+          $ref: '#/components/responses/InternalServerError' 
+
     # --------------------------------------------
     
     delete:
       tags:
         - Books
       summary: Delete a book by ID
+      security:
+        - ApiKeyAuth: []
       description: Soft deletes a book by setting its state to 'deleted'.
       operationId: deleteBookById
       parameters:
@@ -347,19 +326,10 @@ paths:
       responses:
         '204':
           description: Book deleted successfully.
+          content: {}
+        '401':
+          $ref: '#/components/responses/Unauthorized' 
         '404':
-          description: Book not found. The requested book ID does not exist.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-              example:
-                error: "Book not found"
+          $ref: '#/components/responses/NotFound' 
         '500':
-          description: Internal Server Error. An unexpected error occurred on the server.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-              example:
-                error: "An unexpected error occurred."
+          $ref: '#/components/responses/InternalServerError' 

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+pythonpath = .

--- a/scripts/delete_books.py
+++ b/scripts/delete_books.py
@@ -7,7 +7,9 @@ Exits with status code 1 on failure (e.g., cannot connect to the database).
 """
 
 import sys
+
 from pymongo.errors import ConnectionFailure
+
 from app import create_app
 from app.datastore.mongo_db import get_book_collection
 
@@ -37,7 +39,7 @@ def main():
     """
     Starts the Flask app context, connects to MongoDB, and deletes all
     documents in the books collection.
-    
+
     Returns:
         int: 0 on success, 1 on failure.
     """
@@ -62,7 +64,9 @@ def main():
             # This is a critical failure. The script could not do its job.
             # Printing to sys.stderr is best practice for error messages.
             print("❌ ERROR: Could not connect to MongoDB.", file=sys.stderr)
-            print("Please ensure the database is running and accessible.", file=sys.stderr)
+            print(
+                "Please ensure the database is running and accessible.", file=sys.stderr
+            )
             print(f"Details: {e}", file=sys.stderr)
 
             # Return the failure code.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,14 +7,15 @@ This file contains shared fixtures and helpers that are automatically discovered
 
 import mongomock
 import pytest
+from app import create_app
 
 
 @pytest.fixture(name="mock_books_collection")
 def mock_books_collection_fixture():
     """Provides an in-memory, empty 'books' collection for each test."""
     # mongomock.MongoClient() creates a fake client.
-    client = mongomock.MongoClient()
-    db = client["test_database"]
+    mongo_client = mongomock.MongoClient()
+    db = mongo_client["test_database"]
     return db["test_books_collection"]
 
 
@@ -47,3 +48,17 @@ def sample_book_data():
             "state": "active",
         },
     ]
+
+@pytest.fixture()
+def test_app():
+    """Creates an app with a specific 'TESTING' config"""
+    app = create_app({
+        "TESTING": True, 
+        "API_KEY": "test-key-123"
+        })
+    yield app
+
+@pytest.fixture(name="test_client")
+def client(app):
+    """A test client for the app."""
+    return app.test_client()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -51,14 +51,14 @@ def sample_book_data():
 
 @pytest.fixture()
 def test_app():
-    """Creates an app with a specific 'TESTING' config"""
+    """Creates an app with a specific 'TESTING' config."""
     app = create_app({
-        "TESTING": True, 
+        "TESTING": True,
         "API_KEY": "test-key-123"
-        })
+    })
     yield app
 
 @pytest.fixture(name="test_client")
-def client(app):
+def client(test_app): # pylint: disable=redefined-outer-name
     """A test client for the app."""
-    return app.test_client()
+    return test_app.test_client()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,8 +5,10 @@ A configuration file for pytest.
 This file contains shared fixtures and helpers that are automatically discovered by pytest and made available to all tests.
 """
 from unittest.mock import patch
+
 import mongomock
 import pytest
+
 from app import create_app
 
 
@@ -58,23 +60,27 @@ def sample_book_data():
         },
     ]
 
+
 @pytest.fixture()
 def test_app():
     """
     Creates the Flask app instance configured for testing.
     This is the single source of truth for the test app.
     """
-    app = create_app({
-        "TESTING": True,
-        "TRAP_HTTP_EXCEPTIONS": True,
-        "API_KEY": "test-key-123",
-        "MONGO_URI": "mongodb://localhost:27017/",
-        "DB_NAME": "test_database",
-        "COLLECTION_NAME": "test_books"
-    })
+    app = create_app(
+        {
+            "TESTING": True,
+            "TRAP_HTTP_EXCEPTIONS": True,
+            "API_KEY": "test-key-123",
+            "MONGO_URI": "mongodb://localhost:27017/",
+            "DB_NAME": "test_database",
+            "COLLECTION_NAME": "test_books",
+        }
+    )
     yield app
 
+
 @pytest.fixture(name="client")
-def client(test_app): # pylint: disable=redefined-outer-name
+def client(test_app):  # pylint: disable=redefined-outer-name
     """A test client for the app."""
     return test_app.test_client()

--- a/tests/test_api_security.py
+++ b/tests/test_api_security.py
@@ -1,13 +1,10 @@
+# pylint: disable=missing-docstring
 """
 Tests for API security features, such as API key authentication.
 """
 
-def test_create_book_fails_without_api_key(test_client, monkeypatch):
-    """
-    GIVEN a Flask application configured for testing
-    WHEN a POST request is made to '/books' WITHOUT an API key in the headers
-    THEN check that the response is 401 Unauthorized
-    """
+def test_create_book_fails_without_api_key(client, monkeypatch):
+
     # 1. Stub out any external dependencies
     monkeypatch.setattr("app.routes.get_book_collection", lambda: None)
     monkeypatch.setattr("app.routes.insert_book_to_mongo", lambda book, collection: None)
@@ -21,7 +18,7 @@ def test_create_book_fails_without_api_key(test_client, monkeypatch):
     }
 
     # 3. Hit the endpoint without Authorization header
-    response = test_client.post("/books", json=payload)
+    response = client.post("/books", json=payload)
     print("Response:", response.get_data(as_text=True))
     print("Status code", response.status_code)
 
@@ -31,7 +28,7 @@ def test_create_book_fails_without_api_key(test_client, monkeypatch):
 
 
 
-def test_create_book_succeeds_with_valid_api_key(test_client, monkeypatch):
+def test_create_book_succeeds_with_valid_api_key(client, monkeypatch):
     """
     GIVEN a Flask application configured for testing
     WHEN a POST request is made to '/books' WITH a valid API key in the headers
@@ -55,6 +52,6 @@ def test_create_book_succeeds_with_valid_api_key(test_client, monkeypatch):
     }
 
     # Pass the headers dictionary to the `headers` argument.
-    response = test_client.post("/books", json=valid_payload, headers=valid_headers)
+    response = client.post("/books", json=valid_payload, headers=valid_headers)
 
     assert response.status_code == 201

--- a/tests/test_api_security.py
+++ b/tests/test_api_security.py
@@ -3,18 +3,21 @@
 Tests for API security features, such as API key authentication.
 """
 
+
 def test_create_book_fails_without_api_key(client, monkeypatch):
 
     # 1. Stub out any external dependencies
     monkeypatch.setattr("app.routes.get_book_collection", lambda: None)
-    monkeypatch.setattr("app.routes.insert_book_to_mongo", lambda book, collection: None)
+    monkeypatch.setattr(
+        "app.routes.insert_book_to_mongo", lambda book, collection: None
+    )
     monkeypatch.setattr("app.routes.append_hostname", lambda book, host: book)
 
     # 2. Build a valid payload, but don't include the header
     payload = {
         "title": "A Test Book",
         "synopsis": "A test synopsis.",
-        "author": "Tester McTestFace"
+        "author": "Tester McTestFace",
     }
 
     # 3. Hit the endpoint without Authorization header
@@ -27,7 +30,6 @@ def test_create_book_fails_without_api_key(client, monkeypatch):
     assert "Invalid or missing API Key" in response.json["error"]["message"]
 
 
-
 def test_create_book_succeeds_with_valid_api_key(client, monkeypatch):
     """
     GIVEN a Flask application configured for testing
@@ -36,19 +38,21 @@ def test_create_book_succeeds_with_valid_api_key(client, monkeypatch):
     """
     # We still need to patch the database for this unit test
     monkeypatch.setattr("app.routes.get_book_collection", lambda: None)
-    monkeypatch.setattr("app.routes.insert_book_to_mongo", lambda book, collection: None)
+    monkeypatch.setattr(
+        "app.routes.insert_book_to_mongo", lambda book, collection: None
+    )
     monkeypatch.setattr("app.routes.append_hostname", lambda book, host: book)
 
     # The payload does NOT contain the key.
     valid_payload = {
         "title": "A Real Book",
         "synopsis": "It's real.",
-        "author": "A. Real Person"
+        "author": "A. Real Person",
     }
 
     # The headers dictionary contains the key.
     valid_headers = {
-        "X-API-KEY": "test-key-123" # This must match the key in conftest.py
+        "X-API-KEY": "test-key-123"  # This must match the key in conftest.py
     }
 
     # Pass the headers dictionary to the `headers` argument.

--- a/tests/test_api_security.py
+++ b/tests/test_api_security.py
@@ -1,0 +1,60 @@
+"""
+Tests for API security features, such as API key authentication.
+"""
+
+def test_create_book_fails_without_api_key(test_client, monkeypatch):
+    """
+    GIVEN a Flask application configured for testing
+    WHEN a POST request is made to '/books' WITHOUT an API key in the headers
+    THEN check that the response is 401 Unauthorized
+    """
+    # 1. Stub out any external dependencies
+    monkeypatch.setattr("app.routes.get_book_collection", lambda: None)
+    monkeypatch.setattr("app.routes.insert_book_to_mongo", lambda book, collection: None)
+    monkeypatch.setattr("app.routes.append_hostname", lambda book, host: book)
+
+    # 2. Build a valid payload, but don't include the header
+    payload = {
+        "title": "A Test Book",
+        "synopsis": "A test synopsis.",
+        "author": "Tester McTestFace"
+    }
+
+    # 3. Hit the endpoint without Authorization header
+    response = test_client.post("/books", json=payload)
+    print("Response:", response.get_data(as_text=True))
+    print("Status code", response.status_code)
+
+    # 4. Assert that you got a 401 back
+    assert response.status_code == 401
+    assert "Invalid or missing API Key" in response.json["error"]["message"]
+
+
+
+def test_create_book_succeeds_with_valid_api_key(test_client, monkeypatch):
+    """
+    GIVEN a Flask application configured for testing
+    WHEN a POST request is made to '/books' WITH a valid API key in the headers
+    THEN check that the response is 201 Created
+    """
+    # We still need to patch the database for this unit test
+    monkeypatch.setattr("app.routes.get_book_collection", lambda: None)
+    monkeypatch.setattr("app.routes.insert_book_to_mongo", lambda book, collection: None)
+    monkeypatch.setattr("app.routes.append_hostname", lambda book, host: book)
+
+    # The payload does NOT contain the key.
+    valid_payload = {
+        "title": "A Real Book",
+        "synopsis": "It's real.",
+        "author": "A. Real Person"
+    }
+
+    # The headers dictionary contains the key.
+    valid_headers = {
+        "X-API-KEY": "test-key-123" # This must match the key in conftest.py
+    }
+
+    # Pass the headers dictionary to the `headers` argument.
+    response = test_client.post("/books", json=valid_payload, headers=valid_headers)
+
+    assert response.status_code == 201

--- a/tests/test_api_security.py
+++ b/tests/test_api_security.py
@@ -61,7 +61,7 @@ def test_create_book_succeeds_with_valid_api_key(client, monkeypatch):
 
     assert response.status_code == 201
 
-# -------------- POST --------------------------
+# -------------- PUT --------------------------
 
 def test_update_book_fails_without_api_key(monkeypatch, client):
     """Should return 401 if no API key is provided."""
@@ -109,3 +109,24 @@ def test_update_book_succeeds_with_api_key(monkeypatch, client):
     # 5. Assert response
     assert response.status_code == 200
     assert response.json["title"] == "New Title"
+
+# -------------- DELETE --------------------------
+def test_delete_book_unauthorized(client):
+    """
+    WHEN a DELETE request is made without an API key
+    THEN the response should be 401 Unauthorized
+    """
+    response = client.delete("/books/some-id")
+    assert response.status_code == 401
+    assert "Invalid or missing API Key" in response.json["error"]["message"]
+
+def test_delete_book_authorized(client, monkeypatch):
+    """
+    WHEN a DELETE request is made with a valid API key
+    THEN it should return 200 OK (or appropriate response)
+    """
+    monkeypatch.setattr("app.routes.books", [{"id": "some-id"}])
+
+    headers = {"X-API-KEY": "test-key-123"}
+    response = client.delete("/books/some-id", headers=headers)
+    assert response.status_code == 204

--- a/tests/test_api_security.py
+++ b/tests/test_api_security.py
@@ -3,25 +3,26 @@
 Tests for API security features, such as API key authentication.
 """
 import logging
+
 import pytest
 
 # -------------- LOGGING --------------------------
 
-@pytest.mark.parametrize("method, path", [
-    ("post", "/books"),
-    ("put", "/books/some-id"),
-    ("delete", "/books/some-id"),
-])
 
+@pytest.mark.parametrize(
+    "method, path",
+    [
+        ("post", "/books"),
+        ("put", "/books/some-id"),
+        ("delete", "/books/some-id"),
+    ],
+)
 def test_invalid_api_key_logs_attempt_for_post_route(client, caplog, method, path):
     caplog.set_level(logging.WARNING)
 
-    invalid_header = {
-        "X-API-KEY": 'This-is-the-wrong-key-12345'
-    }
+    invalid_header = {"X-API-KEY": "This-is-the-wrong-key-12345"}
 
     response = getattr(client, method)(path, headers=invalid_header)
-
 
     assert response.status_code == 401
     assert "Unauthorized access attempt" in caplog.text
@@ -29,6 +30,7 @@ def test_invalid_api_key_logs_attempt_for_post_route(client, caplog, method, pat
 
 
 # -------------- POST --------------------------
+
 
 def test_add_book_fails_with_missing_key(client, monkeypatch):
 
@@ -54,6 +56,7 @@ def test_add_book_fails_with_missing_key(client, monkeypatch):
     # 4. Assert that you got a 401 back
     assert response.status_code == 401
     assert "API key is missing." in response.json["error"]["message"]
+
 
 def test_add_book_succeeds_with_valid_key(client, monkeypatch):
     """
@@ -85,13 +88,12 @@ def test_add_book_succeeds_with_valid_key(client, monkeypatch):
 
     assert response.status_code == 201
 
+
 def test_add_book_fails_with_invalid_key(client):
 
     # ARRANGE
-    invalid_header = {
-        "X-API-KEY": 'This-is-the-wrong-key-12345'
-    }
-     # The payload does NOT contain the key.
+    invalid_header = {"X-API-KEY": "This-is-the-wrong-key-12345"}
+    # The payload does NOT contain the key.
     valid_payload = {
         "title": "A Real Book",
         "synopsis": "It's real.",
@@ -99,11 +101,12 @@ def test_add_book_fails_with_invalid_key(client):
     }
 
     # ACT
-    response = client.post('/books', json=valid_payload, headers=invalid_header)
+    response = client.post("/books", json=valid_payload, headers=invalid_header)
 
     # ASSERT: Verify the server rejected the request as expected.
     assert response.status_code == 401
     assert "Invalid API key." in response.json["error"]["message"]
+
 
 def test_add_book_fails_if_api_key_not_configured_on_the_server(client, test_app):
     # ARRANGE: Remove API_KEY from the test_app config
@@ -115,7 +118,7 @@ def test_add_book_fails_if_api_key_not_configured_on_the_server(client, test_app
         "author": "Tester McTestFace",
     }
 
-    response = client.post('/books', json=payload)
+    response = client.post("/books", json=payload)
 
     assert response.status_code == 500
     assert "API key not configured on the server." in response.json["error"]["message"]
@@ -126,12 +129,14 @@ def test_update_book_succeeds_with_valid_api_key(monkeypatch, client):
     """Test successful book update with valid API key."""
 
     # 1. Patch the books list
-    test_books = [{
-        "id": "abc123",
-        "title": "Old Title",
-        "synopsis": "Old Synopsis",
-        "author": "Old Author"
-    }]
+    test_books = [
+        {
+            "id": "abc123",
+            "title": "Old Title",
+            "synopsis": "Old Synopsis",
+            "author": "Old Author",
+        }
+    ]
     monkeypatch.setattr("app.routes.books", test_books)
 
     # 2. Patch append_hostname to just return the book
@@ -139,11 +144,7 @@ def test_update_book_succeeds_with_valid_api_key(monkeypatch, client):
 
     # 3. Build request
     headers = {"X-API-KEY": "test-key-123"}
-    payload = {
-        "title": "New Title",
-        "synopsis": "New Synopsis",
-        "author": "New Author"
-    }
+    payload = {"title": "New Title", "synopsis": "New Synopsis", "author": "New Author"}
 
     # 4. Call the endpoint
     response = client.put("/books/abc123", json=payload, headers=headers)
@@ -152,39 +153,38 @@ def test_update_book_succeeds_with_valid_api_key(monkeypatch, client):
     assert response.status_code == 200
     assert response.json["title"] == "New Title"
 
+
 def test_update_book_fails_with_missing_api_key(monkeypatch, client):
     """Should return 401 if no API key is provided."""
 
     monkeypatch.setattr("app.routes.books", [])
 
-    payload = {
-        "title": "New Title",
-        "synopsis": "New Synopsis",
-        "author": "New Author"
-    }
+    payload = {"title": "New Title", "synopsis": "New Synopsis", "author": "New Author"}
 
     response = client.put("/books/abc123", json=payload)
 
     assert response.status_code == 401
     assert "API key is missing." in response.json["error"]["message"]
 
+
 def test_update_book_fails_with_invalid_api_key(client, monkeypatch):
     monkeypatch.setattr("app.routes.books", [])
-    invalid_header = {
-        "X-API-KEY": 'This-is-the-wrong-key-12345'
-    }
+    invalid_header = {"X-API-KEY": "This-is-the-wrong-key-12345"}
     payload = {
         "title": "A Test Book",
         "synopsis": "A test synopsis.",
         "author": "Tester McTestFace",
     }
 
-    response = client.put('/books/abc123', json=payload, headers=invalid_header)
+    response = client.put("/books/abc123", json=payload, headers=invalid_header)
     # ASSERT: Verify the server rejected the request as expected.
     assert response.status_code == 401
     assert "Invalid API key." in response.json["error"]["message"]
 
-def test_update_book_fails_if_api_key_not_configured_on_the_server(client, test_app, monkeypatch):
+
+def test_update_book_fails_if_api_key_not_configured_on_the_server(
+    client, test_app, monkeypatch
+):
     # ARRANGE: Remove API_KEY from the test_app config
     monkeypatch.setattr("app.routes.books", [])
     test_app.config.pop("API_KEY", None)
@@ -195,7 +195,7 @@ def test_update_book_fails_if_api_key_not_configured_on_the_server(client, test_
         "author": "Tester McTestFace",
     }
 
-    response = client.put('/books/abc123', json=payload)
+    response = client.put("/books/abc123", json=payload)
 
     assert response.status_code == 500
     assert "API key not configured on the server." in response.json["error"]["message"]
@@ -211,6 +211,7 @@ def test_delete_book_fails_with_invalid_api_key(client):
     assert response.status_code == 401
     assert "API key is missing." in response.json["error"]["message"]
 
+
 def test_delete_book_succeeds_with_valid_api_key(client, monkeypatch):
     """
     WHEN a DELETE request is made with a valid API key
@@ -222,16 +223,16 @@ def test_delete_book_succeeds_with_valid_api_key(client, monkeypatch):
     response = client.delete("/books/some-id", headers=headers)
     assert response.status_code == 204
 
-def test_delete_book_fails_with_invalid_key(client):
-    invalid_header = {
-        "X-API-KEY": 'This-is-the-wrong-key-12345'
-    }
 
-    response = client.delete('/books/any-book-id', headers=invalid_header)
+def test_delete_book_fails_with_invalid_key(client):
+    invalid_header = {"X-API-KEY": "This-is-the-wrong-key-12345"}
+
+    response = client.delete("/books/any-book-id", headers=invalid_header)
 
     # ASSERT: Verify the server rejected the request as expected.
     assert response.status_code == 401
     assert "Invalid API key." in response.json["error"]["message"]
+
 
 def test_delete_book_fails_if_api_key_not_configured_on_the_server(client, test_app):
     test_app.config.pop("API_KEY", None)
@@ -242,7 +243,7 @@ def test_delete_book_fails_if_api_key_not_configured_on_the_server(client, test_
         "author": "Tester McTestFace",
     }
 
-    response = client.put('/books/any-book-id', json=payload)
+    response = client.put("/books/any-book-id", json=payload)
 
     assert response.status_code == 500
     assert "API key not configured on the server." in response.json["error"]["message"]

--- a/tests/test_api_security.py
+++ b/tests/test_api_security.py
@@ -2,6 +2,31 @@
 """
 Tests for API security features, such as API key authentication.
 """
+import logging
+import pytest
+
+# -------------- LOGGING --------------------------
+
+@pytest.mark.parametrize("method, path", [
+    ("post", "/books"),
+    ("put", "/books/some-id"),
+    ("delete", "/books/some-id"),
+])
+
+def test_invalid_api_key_logs_attempt_for_post_route(client, caplog, method, path):
+    caplog.set_level(logging.WARNING)
+
+    invalid_header = {
+        "X-API-KEY": 'This-is-the-wrong-key-12345'
+    }
+
+    response = getattr(client, method)(path, headers=invalid_header)
+
+
+    assert response.status_code == 401
+    assert "Unauthorized access attempt" in caplog.text
+    assert "/books" in caplog.text
+
 
 # -------------- POST --------------------------
 

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -8,7 +8,6 @@ from pymongo.errors import ServerSelectionTimeoutError
 from app import create_app
 from app.datastore.mongo_db import get_book_collection
 
-
 # Mock book database object
 books_database = [
     {
@@ -51,6 +50,7 @@ books_database = [
 
 # ------------------- Tests for POST ---------------------------------------------
 
+
 def test_add_book_creates_new_book(client, _insert_book_to_db):
 
     test_book = {
@@ -60,9 +60,7 @@ def test_add_book_creates_new_book(client, _insert_book_to_db):
     }
 
     # Define the valid headers, including the API key that matches conftest.py
-    valid_headers = {
-        "X-API-KEY": "test-key-123"
-    }
+    valid_headers = {"X-API-KEY": "test-key-123"}
 
     response = client.post("/books", json=test_book, headers=valid_headers)
 
@@ -83,9 +81,7 @@ def test_add_book_sent_with_missing_required_fields(client):
     }
 
     # Define the valid headers, including the API key that matches conftest.py
-    valid_headers = {
-        "X-API-KEY": "test-key-123"
-    }
+    valid_headers = {"X-API-KEY": "test-key-123"}
     response = client.post("/books", json=test_book, headers=valid_headers)
 
     assert response.status_code == 400
@@ -95,16 +91,10 @@ def test_add_book_sent_with_missing_required_fields(client):
 
 
 def test_add_book_sent_with_wrong_types(client):
-    test_book = {
-        "title": 1234567, 
-        "author": "AN Other", 
-        "synopsis": "Test Synopsis"
-        }
+    test_book = {"title": 1234567, "author": "AN Other", "synopsis": "Test Synopsis"}
 
- # Define the valid headers, including the API key that matches conftest.py
-    valid_headers = {
-        "X-API-KEY": "test-key-123"
-    }
+    # Define the valid headers, including the API key that matches conftest.py
+    valid_headers = {"X-API-KEY": "test-key-123"}
     response = client.post("/books", json=test_book, headers=valid_headers)
 
     assert response.status_code == 400
@@ -115,23 +105,21 @@ def test_add_book_sent_with_wrong_types(client):
 
 def test_add_book_with_invalid_json_content(client):
 
-     # Define the valid headers, including the API key that matches conftest.py
-    valid_headers = {
-        "X-API-KEY": "test-key-123"
-    }
+    # Define the valid headers, including the API key that matches conftest.py
+    valid_headers = {"X-API-KEY": "test-key-123"}
 
     # This should trigger a TypeError
-    response = client.post("/books", json="This is not a JSON object", headers=valid_headers)
+    response = client.post(
+        "/books", json="This is not a JSON object", headers=valid_headers
+    )
 
     assert response.status_code == 400
     assert "JSON payload must be a dictionary" in response.get_json()["error"]
 
 
 def test_add_book_check_request_header_is_json(client):
-     # Define the valid headers, including the API key that matches conftest.py
-    valid_headers = {
-        "X-API-KEY": "test-key-123"
-    }
+    # Define the valid headers, including the API key that matches conftest.py
+    valid_headers = {"X-API-KEY": "test-key-123"}
 
     response = client.post(
         "/books",
@@ -149,10 +137,8 @@ def test_500_response_is_json(client):
         "author": "AN Other",
         "synopsis": "Test Synopsis",
     }
-     # Define the valid headers, including the API key that matches conftest.py
-    valid_headers = {
-        "X-API-KEY": "test-key-123"
-    }
+    # Define the valid headers, including the API key that matches conftest.py
+    valid_headers = {"X-API-KEY": "test-key-123"}
 
     # Use patch to mock uuid module failing and throwing an exception
     with patch("uuid.uuid4", side_effect=Exception("An unexpected error occurred")):
@@ -498,10 +484,8 @@ def test_append_host_to_links_in_post(client, _insert_book_to_db):
         "author": "AN Other II",
         "synopsis": "Test Synopsis",
     }
-     # Define the valid headers, including the API key that matches conftest.py
-    valid_headers = {
-        "X-API-KEY": "test-key-123"
-    }
+    # Define the valid headers, including the API key that matches conftest.py
+    valid_headers = {"X-API-KEY": "test-key-123"}
 
     response = client.post("/books", json=test_book, headers=valid_headers)
 

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -352,9 +352,13 @@ def test_update_book_request_returns_correct_status_and_content_type(client):
             "author": "AN Other",
             "synopsis": "Test Synopsis",
         }
+        # Define the valid headers, including the API key that matches conftest.py
+        valid_headers = {
+            "X-API-KEY": "test-key-123"
+        }
 
         # send PUT request
-        response = client.put("/books/1", json=test_book)
+        response = client.put("/books/1", json=test_book, headers=valid_headers)
 
         # Check response status code and content type
         assert response.status_code == 200
@@ -368,9 +372,13 @@ def test_update_book_request_returns_required_fields(client):
             "author": "AN Other",
             "synopsis": "Test Synopsis",
         }
+        # Define the valid headers, including the API key that matches conftest.py
+        valid_headers = {
+            "X-API-KEY": "test-key-123"
+        }
 
         # Send PUT request
-        response = client.put("/books/1", json=test_book)
+        response = client.put("/books/1", json=test_book, headers=valid_headers)
         response_data = response.get_json()
 
         # Check that required fields are in the response data
@@ -398,8 +406,11 @@ def test_update_book_replaces_whole_object(client):
             "author": "Updated Author",
             "synopsis": "Updated Synopsis",
         }
-
-        response = client.put("/books/1", json=updated_data)
+        # Define the valid headers, including the API key that matches conftest.py
+        valid_headers = {
+            "X-API-KEY": "test-key-123"
+        }
+        response = client.put("/books/1", json=updated_data, headers=valid_headers)
         assert response.status_code == 200
 
         data = response.get_json()
@@ -421,7 +432,11 @@ def test_update_book_sent_with_invalid_book_id(client):
             "author": "Some author",
             "synopsis": "Some synopsis",
         }
-        response = client.put("/books/999", json=test_book)
+        # Define the valid headers, including the API key that matches conftest.py
+        valid_headers = {
+            "X-API-KEY": "test-key-123"
+        }
+        response = client.put("/books/999", json=test_book, headers=valid_headers)
         assert response.status_code == 404
         assert "Book not found" in response.get_json()["error"]
 
@@ -433,9 +448,12 @@ def test_book_database_is_initialized_for_update_book_route(client):
             "author": "AN Other",
             "synopsis": "Test Synopsis",
         }
-
+        # Define the valid headers, including the API key that matches conftest.py
+        valid_headers = {
+            "X-API-KEY": "test-key-123"
+        }
         # Send PUT request
-        response = client.put("/books/1", json=test_book)
+        response = client.put("/books/1", json=test_book, headers=valid_headers)
         assert response.status_code == 500
         assert "Book collection not initialized" in response.get_json()["error"]
 
@@ -445,7 +463,10 @@ def test_update_book_check_request_header_is_json(client):
     response = client.put(
         "/books/1",
         data="This is not a JSON object",
-        headers={"content-type": "text/plain"},
+        headers={
+            "content-type": "text/plain",
+            "X-API-KEY": "test-key-123"
+            },
     )
 
     assert response.status_code == 415
@@ -453,9 +474,13 @@ def test_update_book_check_request_header_is_json(client):
 
 
 def test_update_book_with_invalid_json_content(client):
+    # Define the valid headers, including the API key that matches conftest.py
+    valid_headers = {
+        "X-API-KEY": "test-key-123"
+    }
 
     # This should trigger a TypeError
-    response = client.put("/books/1", json="This is not a JSON object")
+    response = client.put("/books/1", json="This is not a JSON object", headers=valid_headers)
 
     assert response.status_code == 400
     assert "JSON payload must be a dictionary" in response.get_json()["error"]
@@ -466,7 +491,12 @@ def test_update_book_sent_with_missing_required_fields(client):
         "author": "AN Other"
         # missing 'title' and 'synopsis'
     }
-    response = client.put("/books/1", json=test_book)
+    # Define the valid headers, including the API key that matches conftest.py
+    valid_headers = {
+        "X-API-KEY": "test-key-123"
+    }
+
+    response = client.put("/books/1", json=test_book, headers=valid_headers)
 
     assert response.status_code == 400
     response_data = response.get_json()
@@ -573,7 +603,12 @@ def test_append_host_to_links_in_put(client):
         "author": "AN Other",
         "synopsis": "Test Synopsis",
     }
-    response = client.put("/books/1", json=test_book)
+    # Define the valid headers, including the API key that matches conftest.py
+    valid_headers = {
+        "X-API-KEY": "test-key-123"
+    }
+
+    response = client.put("/books/1", json=test_book, headers=valid_headers)
 
     assert response.status_code == 200
     assert response.headers["content-type"] == "application/json"

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -309,9 +309,10 @@ def test_get_book_returns_404_if_state_equals_deleted(client):
 
 def test_book_is_soft_deleted_on_delete_request(client):
     with patch("app.routes.books", books_database):
-        # Send DELETE request
+        # Send DELETE request with valid API header
         book_id = "1"
-        response = client.delete(f"/books/{book_id}")
+        headers = {"X-API-KEY": "test-key-123"}
+        response = client.delete(f"/books/{book_id}", headers=headers)
 
         assert response.status_code == 204
         assert response.data == b""
@@ -328,7 +329,8 @@ def test_delete_empty_book_id(client):
 
 
 def test_delete_invalid_book_id(client):
-    response = client.delete("/books/12341234")
+    headers = {"X-API-KEY": "test-key-123"}
+    response = client.delete("/books/12341234", headers=headers)
     assert response.status_code == 404
     assert response.content_type == "application/json"
     assert "Book not found" in response.get_json()["error"]
@@ -336,7 +338,8 @@ def test_delete_invalid_book_id(client):
 
 def test_book_database_is_initialized_for_delete_book_route(client):
     with patch("app.routes.books", None):
-        response = client.delete("/books/1")
+        headers = {"X-API-KEY": "test-key-123"}
+        response = client.delete("/books/1", headers=headers)
         assert response.status_code == 500
         assert "Book collection not initialized" in response.get_json()["error"]
 

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -356,9 +356,7 @@ def test_update_book_request_returns_correct_status_and_content_type(client):
             "synopsis": "Test Synopsis",
         }
         # Define the valid headers, including the API key that matches conftest.py
-        valid_headers = {
-            "X-API-KEY": "test-key-123"
-        }
+        valid_headers = {"X-API-KEY": "test-key-123"}
 
         # send PUT request
         response = client.put("/books/1", json=test_book, headers=valid_headers)
@@ -376,9 +374,7 @@ def test_update_book_request_returns_required_fields(client):
             "synopsis": "Test Synopsis",
         }
         # Define the valid headers, including the API key that matches conftest.py
-        valid_headers = {
-            "X-API-KEY": "test-key-123"
-        }
+        valid_headers = {"X-API-KEY": "test-key-123"}
 
         # Send PUT request
         response = client.put("/books/1", json=test_book, headers=valid_headers)
@@ -410,9 +406,7 @@ def test_update_book_replaces_whole_object(client):
             "synopsis": "Updated Synopsis",
         }
         # Define the valid headers, including the API key that matches conftest.py
-        valid_headers = {
-            "X-API-KEY": "test-key-123"
-        }
+        valid_headers = {"X-API-KEY": "test-key-123"}
         response = client.put("/books/1", json=updated_data, headers=valid_headers)
         assert response.status_code == 200
 
@@ -436,9 +430,7 @@ def test_update_book_sent_with_invalid_book_id(client):
             "synopsis": "Some synopsis",
         }
         # Define the valid headers, including the API key that matches conftest.py
-        valid_headers = {
-            "X-API-KEY": "test-key-123"
-        }
+        valid_headers = {"X-API-KEY": "test-key-123"}
         response = client.put("/books/999", json=test_book, headers=valid_headers)
         assert response.status_code == 404
         assert "Book not found" in response.get_json()["error"]
@@ -452,9 +444,7 @@ def test_book_database_is_initialized_for_update_book_route(client):
             "synopsis": "Test Synopsis",
         }
         # Define the valid headers, including the API key that matches conftest.py
-        valid_headers = {
-            "X-API-KEY": "test-key-123"
-        }
+        valid_headers = {"X-API-KEY": "test-key-123"}
         # Send PUT request
         response = client.put("/books/1", json=test_book, headers=valid_headers)
         assert response.status_code == 500
@@ -466,10 +456,7 @@ def test_update_book_check_request_header_is_json(client):
     response = client.put(
         "/books/1",
         data="This is not a JSON object",
-        headers={
-            "content-type": "text/plain",
-            "X-API-KEY": "test-key-123"
-            },
+        headers={"content-type": "text/plain", "X-API-KEY": "test-key-123"},
     )
 
     assert response.status_code == 415
@@ -478,12 +465,12 @@ def test_update_book_check_request_header_is_json(client):
 
 def test_update_book_with_invalid_json_content(client):
     # Define the valid headers, including the API key that matches conftest.py
-    valid_headers = {
-        "X-API-KEY": "test-key-123"
-    }
+    valid_headers = {"X-API-KEY": "test-key-123"}
 
     # This should trigger a TypeError
-    response = client.put("/books/1", json="This is not a JSON object", headers=valid_headers)
+    response = client.put(
+        "/books/1", json="This is not a JSON object", headers=valid_headers
+    )
 
     assert response.status_code == 400
     assert "JSON payload must be a dictionary" in response.get_json()["error"]
@@ -495,9 +482,7 @@ def test_update_book_sent_with_missing_required_fields(client):
         # missing 'title' and 'synopsis'
     }
     # Define the valid headers, including the API key that matches conftest.py
-    valid_headers = {
-        "X-API-KEY": "test-key-123"
-    }
+    valid_headers = {"X-API-KEY": "test-key-123"}
 
     response = client.put("/books/1", json=test_book, headers=valid_headers)
 
@@ -607,9 +592,7 @@ def test_append_host_to_links_in_put(client):
         "synopsis": "Test Synopsis",
     }
     # Define the valid headers, including the API key that matches conftest.py
-    valid_headers = {
-        "X-API-KEY": "test-key-123"
-    }
+    valid_headers = {"X-API-KEY": "test-key-123"}
 
     response = client.put("/books/1", json=test_book, headers=valid_headers)
 

--- a/tests/test_delete_books.py
+++ b/tests/test_delete_books.py
@@ -1,6 +1,8 @@
 # pylint: disable=missing-docstring,line-too-long
 from unittest.mock import MagicMock, patch
+
 from pymongo.errors import ConnectionFailure
+
 from scripts.delete_books import delete_all_books, main
 
 # ----------------- TEST SUITE ---------------------------------
@@ -98,8 +100,10 @@ def test_delete_all_books_clears_collection_and_returns_count(
     assert mock_books_collection.count_documents({}) == 0
 
 
-@patch('scripts.delete_books.get_book_collection',
-side_effect=ConnectionFailure("Mock DB connection error"))
+@patch(
+    "scripts.delete_books.get_book_collection",
+    side_effect=ConnectionFailure("Mock DB connection error"),
+)
 def test_main_handles_connection_failure_gracefully(mock_get_book_collection, capsys):
     # ACT
     exit_code = main()

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -2,8 +2,6 @@
 import pytest
 from pymongo import MongoClient
 
-from app import create_app
-
 
 @pytest.fixture(name="mongo_client")
 def mongo_client_fixture():
@@ -27,10 +25,8 @@ def test_post_route_inserts_to_mongodb(mongo_client, client):
         "synopsis": "A novel about all the choices that go into a life well lived.",
         "author": "Matt Haig",
     }
-     # Define the valid headers, including the API key that matches conftest.py
-    valid_headers = {
-        "X-API-KEY": "test-key-123"
-    }
+    # Define the valid headers, including the API key that matches conftest.py
+    valid_headers = {"X-API-KEY": "test-key-123"}
 
     # Act- send the POST request:
     response = client.post("/books", json=new_book_payload, headers=valid_headers)

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -5,17 +5,6 @@ from pymongo import MongoClient
 from app import create_app
 
 
-@pytest.fixture(name="client")
-def client_fixture():
-    """Provides a test client for making requests to our Flask app."""
-    app = create_app()
-    app.config["TESTING"] = True
-    app.config["MONGO_URI"] = "mongodb://localhost:27017/"
-    app.config["DB_NAME"] = "test_database"
-    app.config["COLLECTION_NAME"] = "test_books"
-    return app.test_client()
-
-
 @pytest.fixture(name="mongo_client")
 def mongo_client_fixture():
     """Provides a raw MongoDB client for direct DB access in tests."""
@@ -38,9 +27,13 @@ def test_post_route_inserts_to_mongodb(mongo_client, client):
         "synopsis": "A novel about all the choices that go into a life well lived.",
         "author": "Matt Haig",
     }
+     # Define the valid headers, including the API key that matches conftest.py
+    valid_headers = {
+        "X-API-KEY": "test-key-123"
+    }
 
     # Act- send the POST request:
-    response = client.post("/books", json=new_book_payload)
+    response = client.post("/books", json=new_book_payload, headers=valid_headers)
 
     # Assert:
     assert response.status_code == 201


### PR DESCRIPTION
## Description

Trello card: https://trello.com/c/MkArdXgF

This PR addresses the requirement to secure write-access endpoints (POST, PUT, DELETE) to prevent unauthorized modifications to the book collection.

As per the discussion in the Trello card, this work implements a simple and robust API key authentication strategy. This was chosen as a pragmatic first step to meet the immediate security need, with a more complex user-based solution like OAuth2 being considered for a future iteration.

The implementation includes:

- API Key Authentication: A @require_api_key decorator was created to protect routes. It uses a constant-time comparison (hmac.compare_digest) to prevent timing attacks, and features enhanced logging for unauthorized access attempts.
- Standardized Error Handling (Breaking Change): A global, structured error handler (handle_http_exception) was introduced. All HTTP exceptions now return a consistent JSON object ({ "error": { "code", "name", "message" } }), which is a major improvement for API clients.
- Comprehensive Test Suite: A full suite of tests was added for the new security layer. The tests were then refactored using pytest.mark.parametrize to eliminate repetition and improve maintainability.
- Full Documentation Update: The openapi.yml documentation has been thoroughly updated to reflect the new security requirements on protected routes and, most importantly, the new structured error response schema.

## Type of change
[x] New feature (non-breaking change which adds functionality)
[x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
[x] This change requires a documentation update
[x] Code refactor (improving code quality without changing functionality)

## How Has This Been Tested?
- Automated testing using fixtures for the test application and client, security failure scenarios which covers cases of invalid key, missing key, server key not configured for every protected endpoint.
-  Manual Testing (e.g., DELETE /books/{id}) without a valid API key.
Example using curl:
Generated bash
```
# Attempt to delete a book with an invalid key
curl -i -X DELETE http://localhost:5000/books/some-id \
-H "X-API-KEY: this-is-a-wrong-key"
```
- CI/CD with GitActions

## Checklist:
[x] My code follows the style guidelines of this project
[x] I have performed a self-review of my own code
[x] My individual commit messages are descriptive and follow our [commit guidelines](https://www.google.com/url?sa=E&q=https%3A%2F%2Fmartijnhols.nl%2Fblog%2Fhow-to-write-a-good-git-commit-message%2F)
[x] I have commented my code, particularly in hard-to-understand areas
[x] I have made corresponding changes to the documentation
[x] My changes generate no new warnings
[x] I have added tests that prove my fix is effective or that my feature works
[x] New and existing unit tests pass locally with my changes
[x] Any dependent changes have been merged and published in downstream modules

## Any other information:
IMPORTANT: This is a BREAKING CHANGE for two reasons:
1. Authentication is now required: The POST /books, PUT /books/{id}, and DELETE /books/{id} endpoints, which were previously open, now require a valid X-API-KEY header. Any client not providing this header will receive a 401 Unauthorized error.
2. Error Response Format has changed: The structure of all error responses from the API has been standardized. This will affect any client that was parsing the old error format.

Before this change:
Generated json
```
{
    "error": "Invalid API key."
}
```
After this change, example of the new structured error response:
Generated json
```
{
  "error": {
    "code": 401,
    "name": "Unauthorized",
    "message": "Invalid API key."
  }
}
```