### PR TITLE
Add POST /books/{book_id}/reservations (JWT-protected)

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,3 +1,4 @@
+# pylint: disable=import-outside-toplevel
 """Initialize the Flask app and register all routes."""
 
 import os
@@ -25,12 +26,15 @@ def create_app(test_config=None):
 
     # Import blueprints inside the factory
     from app.routes.auth_routes import \
-        auth_bp  # pylint: disable=import-outside-toplevel
+        auth_bp
     from app.routes.legacy_routes import \
-        register_legacy_routes  # pylint: disable=import-outside-toplevel
+        register_legacy_routes
+    from app.routes.reservation_routes import \
+        reservations_bp
 
     # Register routes with app instance
     register_legacy_routes(app)
     app.register_blueprint(auth_bp)
+    app.register_blueprint(reservations_bp)
 
     return app

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -25,12 +25,9 @@ def create_app(test_config=None):
     bcrypt.init_app(app)
 
     # Import blueprints inside the factory
-    from app.routes.auth_routes import \
-        auth_bp
-    from app.routes.legacy_routes import \
-        register_legacy_routes
-    from app.routes.reservation_routes import \
-        reservations_bp
+    from app.routes.auth_routes import auth_bp
+    from app.routes.legacy_routes import register_legacy_routes
+    from app.routes.reservation_routes import reservations_bp
 
     # Register routes with app instance
     register_legacy_routes(app)

--- a/app/config.py
+++ b/app/config.py
@@ -25,6 +25,7 @@ class Config:
 
     # General config
     SECRET_KEY = os.environ.get("SECRET_KEY")
+    JWT_SECRET_KEY = os.environ.get("JWT_SECRET_KEY")
     FLASK_APP = os.environ.get("FLASK_APP")
     FLASK_ENV = os.environ.get("FLASK")  # values will be 'development' or 'production'
     API_KEY = os.environ.get("API_KEY")

--- a/app/routes/auth_routes.py
+++ b/app/routes/auth_routes.py
@@ -104,11 +104,11 @@ def login_user():
         + datetime.timedelta(hours=24),  # expiration
     }
 
-    # 5. Encode the token with our app's SECRET_KEY
+    # 5. Encode the token with our app's JWT_SECRET_KEY
     try:
         token = jwt.encode(
             payload,
-            current_app.config["SECRET_KEY"],
+            current_app.config["JWT_SECRET_KEY"],
             algorithm="HS256",  # the standard signing algorithm
         )
         return jsonify({"token": token}), 200

--- a/app/routes/reservation_routes.py
+++ b/app/routes/reservation_routes.py
@@ -15,8 +15,6 @@ def create_reservation(book_id_str):
     """..."""
 
     # ---------- VALIDATION 1 - check payload has valid id - mongoDB id shape
-    if not book_id_str:
-        return jsonify({"error": "Book ID is required"}), 400
 
     try:
         # convert string to an ObjectId

--- a/app/routes/reservation_routes.py
+++ b/app/routes/reservation_routes.py
@@ -1,0 +1,96 @@
+"""Routes for /books/<id>/reservations endpoint"""
+import datetime
+
+from flask import Blueprint, jsonify, request, url_for
+from bson import ObjectId
+from bson.errors import InvalidId
+from werkzeug.exceptions import BadRequest
+from app.extensions import mongo
+
+
+reservations_bp = Blueprint("reservations_bp", __name__, url_prefix="/books/<book_id_str>")
+
+@reservations_bp.route("/reservations", methods=["POST"])
+def create_reservation(book_id_str):
+    """..."""
+
+    # ---------- VALIDATION 1 - check payload has valid id - mongoDB id shape
+    if not book_id_str:
+        return jsonify({"error": "Book ID is required"}), 400
+
+    try:
+        # convert string to an ObjectId
+        book_id = ObjectId(book_id_str)
+    except (InvalidId, TypeError):
+        return jsonify({"error": "Invalid Book ID"}), 400
+
+    # Check if book exists or throw 404
+    book = mongo.db.books.find_one({"_id": book_id})
+    if not book:
+        return jsonify({"error": "Book not found"}), 404
+
+    # --------- VALIDATION 2
+    # check payload exists & is JSON
+    try:
+        data = request.get_json()
+        if not data:
+            return jsonify({"message": "Request body cannot be empty"}), 400
+
+        errors = {}
+        if "forenames" not in data or not isinstance(data.get("forenames"), str):
+            errors["forenames"] = "forenames is required and must be a string"
+        if "surname" not in data or not isinstance(data.get("surname"), str):
+            errors["surname"] = "surname is required and must be a string"
+        if errors:
+            return jsonify({"error": "Validation failed", "messages": errors}), 400
+
+        # extract data from payload
+        forenames = data.get("forenames")
+        surname = data.get("surname")
+
+        # Clean and split the forenames string into a list of words
+        forenames_list = forenames.strip().split()
+
+        firstname = forenames_list[0]
+        middle_names = ' '.join(forenames_list[1:])
+
+
+    except BadRequest:
+        return jsonify({"message": "Invalid JSON format"}), 400
+
+
+    # 2. DOCUMENT CREATION
+    reservation_doc = {
+        "book_id": book_id,
+        "state": "reserved",
+        "user": {
+            "forenames": firstname,
+            "middlenames": middle_names,
+            "surname": surname
+        },
+        # Add time reservation was made
+        "reservation_date": datetime.datetime.utcnow()
+    }
+
+    # Insert new reservation to MongoDb 'reservation' collection
+    result = mongo.db.reservations.insert_one(reservation_doc)
+    new_reservation_id = result.inserted_id
+
+
+    # 3. RESPONSE PREP
+    response_data = {
+        "id": str(new_reservation_id),
+        "state": reservation_doc["state"],
+        "user": reservation_doc["user"],
+        "book_id": str(reservation_doc["book_id"]),
+        "links": {
+            # HATEOAS-style links: use url_for so routes stay dynamic and consistent.
+            # Note: the argument name passed to url_for must match the parameter
+            # expected by the target view function (e.g. "book_id_str").
+            "self": url_for(".create_reservation", book_id_str=str(book_id), _external=True),
+            "book": url_for("get_book", book_id=str(book_id), _external=True)
+        },
+        "reservation_doc": reservation_doc["reservation_date"].isoformat()
+    }
+
+    return jsonify(response_data), 201

--- a/app/routes/reservation_routes.py
+++ b/app/routes/reservation_routes.py
@@ -1,16 +1,16 @@
 """Routes for /books/<id>/reservations endpoint"""
 import datetime
 
-from flask import Blueprint, jsonify, request, url_for
+from flask import Blueprint, jsonify, url_for, g
 from bson import ObjectId
 from bson.errors import InvalidId
-from werkzeug.exceptions import BadRequest
 from app.extensions import mongo
-
+from app.utils.decorators import require_jwt
 
 reservations_bp = Blueprint("reservations_bp", __name__, url_prefix="/books/<book_id_str>")
 
 @reservations_bp.route("/reservations", methods=["POST"])
+@require_jwt
 def create_reservation(book_id_str):
     """..."""
 
@@ -27,47 +27,14 @@ def create_reservation(book_id_str):
     if not book:
         return jsonify({"error": "Book not found"}), 404
 
-    # --------- VALIDATION 2
-    # check payload exists & is JSON
-    try:
-        data = request.get_json()
+    # Get the current user directly from Flask's 'g'
+    current_user_id = g.current_user["_id"]
 
-        if not isinstance(data, dict) or not data:
-            return jsonify({"error": "Request body must be a non-empty JSON object"}), 400
-
-        errors = {}
-        if "forenames" not in data or not isinstance(data.get("forenames"), str):
-            errors["forenames"] = "forenames is required and must be a string"
-        if "surname" not in data or not isinstance(data.get("surname"), str):
-            errors["surname"] = "surname is required and must be a string"
-        if errors:
-            return jsonify({"error": "Validation failed", "messages": errors}), 400
-
-        # extract data from payload
-        forenames = data.get("forenames")
-        surname = data.get("surname")
-
-        # Clean and split the forenames string into a list of words
-        forenames_list = forenames.strip().split()
-
-        firstname = forenames_list[0]
-        middle_names = ' '.join(forenames_list[1:])
-
-
-    except BadRequest:
-        return jsonify({"message": "Invalid JSON format"}), 400
-
-
-    # 2. DOCUMENT CREATION
+#    2. DOCUMENT CREATION
     reservation_doc = {
         "book_id": book_id,
         "state": "reserved",
-        "user": {
-            "forenames": firstname,
-            "middlenames": middle_names,
-            "surname": surname
-        },
-        # Add time reservation was made
+        "user_id": current_user_id,
         "reservation_date": datetime.datetime.now(datetime.UTC)
     }
 
@@ -75,17 +42,13 @@ def create_reservation(book_id_str):
     result = mongo.db.reservations.insert_one(reservation_doc)
     new_reservation_id = result.inserted_id
 
-
     # 3. RESPONSE PREP
     response_data = {
         "id": str(new_reservation_id),
         "state": reservation_doc["state"],
-        "user": reservation_doc["user"],
+        "user_id": reservation_doc["user_id"],
         "book_id": str(reservation_doc["book_id"]),
         "links": {
-            # HATEOAS-style links: use url_for so routes stay dynamic and consistent.
-            # Note: the argument name passed to url_for must match the parameter
-            # expected by the target view function (e.g. "book_id_str").
             "self": url_for(".create_reservation", book_id_str=str(book_id), _external=True),
             "book": url_for("get_book", book_id=str(book_id), _external=True)
         },

--- a/app/routes/reservation_routes.py
+++ b/app/routes/reservation_routes.py
@@ -31,8 +31,9 @@ def create_reservation(book_id_str):
     # check payload exists & is JSON
     try:
         data = request.get_json()
-        if not data:
-            return jsonify({"message": "Request body cannot be empty"}), 400
+
+        if not isinstance(data, dict) or not data:
+            return jsonify({"error": "Request body must be a non-empty JSON object"}), 400
 
         errors = {}
         if "forenames" not in data or not isinstance(data.get("forenames"), str):

--- a/app/routes/reservation_routes.py
+++ b/app/routes/reservation_routes.py
@@ -89,7 +89,7 @@ def create_reservation(book_id_str):
             "self": url_for(".create_reservation", book_id_str=str(book_id), _external=True),
             "book": url_for("get_book", book_id=str(book_id), _external=True)
         },
-        "reservation_doc": reservation_doc["reservation_date"].isoformat()
+        "reservation_date": reservation_doc["reservation_date"].isoformat()
     }
 
     return jsonify(response_data), 201

--- a/app/routes/reservation_routes.py
+++ b/app/routes/reservation_routes.py
@@ -35,6 +35,16 @@ def create_reservation(book_id_str):
     # Get the current user directly from Flask's 'g'
     current_user_id = g.current_user["_id"]
 
+    #  ---------- VALIDATION 2 - Check for existing reservation
+    # A user should not be able to reserve the same book more than once.
+    existing_reservation = mongo.db.reservations.find_one({
+        "book_id": book_id,
+        "user_id": current_user_id
+    })
+    if existing_reservation:
+        return jsonify({"error": "You have already reserved this book"}), 409
+
+
     #    2. DOCUMENT CREATION
     reservation_doc = {
         "book_id": book_id,

--- a/app/routes/reservation_routes.py
+++ b/app/routes/reservation_routes.py
@@ -69,7 +69,7 @@ def create_reservation(book_id_str):
             "surname": surname
         },
         # Add time reservation was made
-        "reservation_date": datetime.datetime.utcnow()
+        "reservation_date": datetime.datetime.now(datetime.UTC)
     }
 
     # Insert new reservation to MongoDb 'reservation' collection

--- a/app/routes/reservation_routes.py
+++ b/app/routes/reservation_routes.py
@@ -17,7 +17,12 @@ reservations_bp = Blueprint(
 @reservations_bp.route("/reservations", methods=["POST"])
 @require_jwt
 def create_reservation(book_id_str):
-    """..."""
+    """
+    This POST endpoint lets an authenticated user reserve a book by its ID.
+    It validates the ID, checks book availability, 
+    prevents duplicate reservations, 
+    creates the reservation, and returns its details.
+    """
 
     # ---------- VALIDATION 1 - check payload has valid id - mongoDB id shape
 

--- a/app/routes/reservation_routes.py
+++ b/app/routes/reservation_routes.py
@@ -37,13 +37,11 @@ def create_reservation(book_id_str):
 
     #  ---------- VALIDATION 2 - Check for existing reservation
     # A user should not be able to reserve the same book more than once.
-    existing_reservation = mongo.db.reservations.find_one({
-        "book_id": book_id,
-        "user_id": current_user_id
-    })
+    existing_reservation = mongo.db.reservations.find_one(
+        {"book_id": book_id, "user_id": current_user_id}
+    )
     if existing_reservation:
         return jsonify({"error": "You have already reserved this book"}), 409
-
 
     #    2. DOCUMENT CREATION
     reservation_doc = {

--- a/app/routes/reservation_routes.py
+++ b/app/routes/reservation_routes.py
@@ -1,13 +1,18 @@
 """Routes for /books/<id>/reservations endpoint"""
+
 import datetime
 
-from flask import Blueprint, jsonify, url_for, g
 from bson import ObjectId
 from bson.errors import InvalidId
+from flask import Blueprint, g, jsonify, url_for
+
 from app.extensions import mongo
 from app.utils.decorators import require_jwt
 
-reservations_bp = Blueprint("reservations_bp", __name__, url_prefix="/books/<book_id_str>")
+reservations_bp = Blueprint(
+    "reservations_bp", __name__, url_prefix="/books/<book_id_str>"
+)
+
 
 @reservations_bp.route("/reservations", methods=["POST"])
 @require_jwt
@@ -30,12 +35,12 @@ def create_reservation(book_id_str):
     # Get the current user directly from Flask's 'g'
     current_user_id = g.current_user["_id"]
 
-#    2. DOCUMENT CREATION
+    #    2. DOCUMENT CREATION
     reservation_doc = {
         "book_id": book_id,
         "state": "reserved",
         "user_id": current_user_id,
-        "reservation_date": datetime.datetime.now(datetime.UTC)
+        "reservation_date": datetime.datetime.now(datetime.UTC),
     }
 
     # Insert new reservation to MongoDb 'reservation' collection
@@ -49,10 +54,12 @@ def create_reservation(book_id_str):
         "user_id": reservation_doc["user_id"],
         "book_id": str(reservation_doc["book_id"]),
         "links": {
-            "self": url_for(".create_reservation", book_id_str=str(book_id), _external=True),
-            "book": url_for("get_book", book_id=str(book_id), _external=True)
+            "self": url_for(
+                ".create_reservation", book_id_str=str(book_id), _external=True
+            ),
+            "book": url_for("get_book", book_id=str(book_id), _external=True),
         },
-        "reservation_date": reservation_doc["reservation_date"].isoformat()
+        "reservation_date": reservation_doc["reservation_date"].isoformat(),
     }
 
     return jsonify(response_data), 201

--- a/app/utils/decorators.py
+++ b/app/utils/decorators.py
@@ -34,7 +34,7 @@ def require_jwt(f):
         try:
             payload = jwt.decode(
                 token,
-                current_app.config["SECRET_KEY"],
+                current_app.config["JWT_SECRET_KEY"],
                 algorithms=["HS256"],
                 # options={"require": ["exp", "sub"]}  # optional: force required claims
             )

--- a/app/utils/decorators.py
+++ b/app/utils/decorators.py
@@ -3,10 +3,12 @@
 This module provides decorators for Flask routes, including JWT authentication.
 """
 import functools
+
 import jwt
-from flask import current_app, g, jsonify, request
-from bson.objectid import ObjectId
 from bson.errors import InvalidId
+from bson.objectid import ObjectId
+from flask import current_app, g, jsonify, request
+
 from app.extensions import mongo
 
 

--- a/openapi.yml
+++ b/openapi.yml
@@ -180,41 +180,50 @@ components:
 
   # ------- Reservation schemas ----------
 
-    # Schema for what a User looks like 
-    User:
-      type: object
-      properties:
-        userId:
-          type: string
-          example: "user-12345"
-        name:
-          type: string
-          example: "Jane Doe"
-
     # Schema for the POST /reservations request body
     ReservationInput:
       type: object
       required:
-        - user
+        - forenames
+        - surname
       properties:
-        user:
-          $ref: '#/components/schemas/User'
+        forenames:
+          type: string
+          description: The first name and any middle names of the user making the reservation.
+          example: "John Fitzgerald"
+        surname:
+          type: string
+          description: The last name of the user making the reservation.
+          example: "Doe"
 
     # Schema for the PUT /reservations/{res_id} request body
-    ReservationUpdateInput:
+    ReservationUserOutput:
       type: object
-      description: The fields required to fully update a reservation. 
-      required:
-        - user
-        - reservationDate
       properties:
-        user:
-          $ref: '#/components/schemas/User'
-        reservationDate:
+        forenames:
           type: string
-          format: date-time
-          description: The new timestamp for the reservation.
-          example: "2023-10-28T12:00:00Z"
+          example: "John"
+        middlenames:
+          type: string
+          example: "Fitzgerald"
+        surname:
+          type: string
+          example: "Doe"
+          
+    # A schema for the 'links' object in the response.
+    ReservationLinks:
+      type: object
+      properties:
+        self:
+          type: string
+          format: uri
+          description: A link to the reservation resource itself.
+        book:
+          type: string
+          format: uri
+          description: A link to the parent book resource.
+      readOnly: true
+    
 
     # Schema for the full Reservation object returned by the API
     ReservationOutput:
@@ -225,18 +234,26 @@ components:
           description: The unique identifier for the reservation. 
           pattern: '^[a-f\d]{24}$'
           example: "635f3a7f3a8e3bcfc8e6a1f1"
+        state:
+          type: string
+          description: The current state of the reservation.
+          example: "reserved"
+          readOnly: true
+        user:
+          $ref: '#/components/schemas/ReservationUserOutput'
         bookId:
           type: string
           description: The ID of the book being reserved.
           pattern: '^[a-f\d]{24}$'
           example: "635f3a7e3a8e3bcfc8e6a1e0"
+        links:
+          $ref: '#/components/schemas/ReservationLinks'
         reservationDate:
           type: string
           format: date-time
           description: The timestamp when the reservation was made.
           example: "2023-10-27T10:00:00Z"
-        user:
-          $ref: "#/components/schemas/User"
+
 
     # Schema for the GET /reservations response body (a list)
     ReservationsOutput:
@@ -535,10 +552,10 @@ paths:
       tags:
         - Reservations
       summary: Create a reservation for a book.
-      description: Creates a reservation for the book identified by {book_id}.
-      operationId: create_book_reservation
+      description: Creates a reservation for the book identified by {book_id} on behalf of a user.
+      operationId: createBookReservation
       requestBody:
-        description: User information for the reservation.
+        description: The user's name details required to create the reservation.
         required: true
         content:
           application/json:
@@ -552,11 +569,36 @@ paths:
               schema:
                 $ref: '#/components/schemas/ReservationOutput' 
         '400':
-          $ref: '#/components/responses/BadRequest'
+          description: |-
+            Bad Request. Possible reasons include:
+            - The book ID in the path is invalid.
+            - The request body is not valid JSON.
+            - The request body is missing 'forenames' or 'surname'.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SimpleError'
+              examples:
+                invalidId:
+                  summary: Invalid Book ID
+                  value:
+                    error: "Invalid Book ID"
+                validationFailed:
+                  summary: Missing required fields
+                  value:
+                    error: "Validation failed"
+                    messages:
+                      surname: "surname is required and must be a string"
         '401':
           $ref: '#/components/responses/Unauthorized' 
         '404':
-          $ref: '#/components/responses/NotFound'
+          description: The book with the specified ID was not found.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SimpleError'
+              example:
+                error: "Book not found"
         '415':
           $ref: '#/components/responses/UnsupportedMediaType' 
         '500':

--- a/openapi.yml
+++ b/openapi.yml
@@ -180,22 +180,6 @@ components:
 
   # ------- Reservation schemas ----------
 
-    # Schema for the POST /reservations request body
-    ReservationInput:
-      type: object
-      required:
-        - forenames
-        - surname
-      properties:
-        forenames:
-          type: string
-          description: The first name and any middle names of the user making the reservation.
-          example: "John Fitzgerald"
-        surname:
-          type: string
-          description: The last name of the user making the reservation.
-          example: "Doe"
-
     # Schema for the PUT /reservations/{res_id} request body
     ReservationUserOutput:
       type: object
@@ -239,10 +223,13 @@ components:
           description: The current state of the reservation.
           example: "reserved"
           readOnly: true
-        user:
-          $ref: '#/components/schemas/ReservationUserOutput'
-        bookId:
+        user_id:
           type: string
+          description: The ID of the user who made the reservation.
+          pattern: '^[a-f\d]{24}$'
+          example: "635f3a7e3a8e3bcfc8e6a1e0"
+        book_id:
+          tyep: string
           description: The ID of the book being reserved.
           pattern: '^[a-f\d]{24}$'
           example: "635f3a7e3a8e3bcfc8e6a1e0"
@@ -552,15 +539,15 @@ paths:
       tags:
         - Reservations
       summary: Create a reservation for a book.
-      description: Creates a reservation for the book identified by {book_id} on behalf of a user.
+      description: Creates a reservation for the book identified by {book_id} on behalf of the authenticated user. A valid JWT Bearer token is required.
       operationId: createBookReservation
+      security:
+        - bearerAuth: []
       requestBody:
-        description: The user's name details required to create the reservation.
-        required: true
+        description: The request body for this endpoint is ignored. An empty JSON object `{}` is recommended.
         content:
           application/json:
-            schema:
-              $ref: '#/components/schemas/ReservationInput'
+            schema: {}
       responses:
         '201':
           description: Reservation created successfully.
@@ -571,9 +558,8 @@ paths:
         '400':
           description: |-
             Bad Request. Possible reasons include:
-            - The book ID in the path is invalid.
-            - The request body is not valid JSON.
-            - The request body is missing 'forenames' or 'surname'.
+            - The book ID in the path is not a valid MongoDB ObjectId.
+            - The request body is malformed (e.g., not valid JSON).
           content:
             application/json:
               schema:
@@ -583,12 +569,6 @@ paths:
                   summary: Invalid Book ID
                   value:
                     error: "Invalid Book ID"
-                validationFailed:
-                  summary: Missing required fields
-                  value:
-                    error: "Validation failed"
-                    messages:
-                      surname: "surname is required and must be a string"
         '401':
           $ref: '#/components/responses/Unauthorized' 
         '404':
@@ -599,6 +579,14 @@ paths:
                 $ref: '#/components/schemas/SimpleError'
               example:
                 error: "Book not found"
+        '409':
+          description: A reservation for this book by the authenticated user already exists.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SimpleError'
+              example:
+                error: "You have already reserved this book"
         '415':
           $ref: '#/components/responses/UnsupportedMediaType' 
         '500':

--- a/openapi.yml
+++ b/openapi.yml
@@ -229,7 +229,7 @@ components:
           pattern: '^[a-f\d]{24}$'
           example: "635f3a7e3a8e3bcfc8e6a1e0"
         book_id:
-          tyep: string
+          type: string
           description: The ID of the book being reserved.
           pattern: '^[a-f\d]{24}$'
           example: "635f3a7e3a8e3bcfc8e6a1e0"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -174,9 +174,9 @@ def seeded_user_in_db(
     with test_app.app_context():
         mongo.db.users.insert_one(mock_user_data)
 
-    # When yeilding the mock data back to the test,
+    # When yielding the mock data back to the test,
     # we must convert it back the ObjectId back to the string,
-    # becasue that's what 'auth_token' fixture expects to put into the JWT 'sub' claim
+    # because that's what 'auth_token' fixture expects to put into the JWT 'sub' claim
     yield_data = mock_user_data.copy()
     yield_data["_id"] = str(yield_data["_id"])
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,6 +5,7 @@ A configuration file for pytest.
 This file contains shared fixtures and helpers that are automatically discovered by pytest and made available to all tests.
 """
 from unittest.mock import patch
+from bson.objectid import ObjectId
 
 import bcrypt
 import mongomock
@@ -76,6 +77,7 @@ def test_app():
             "TRAP_HTTP_EXCEPTIONS": True,
             "API_KEY": "test-key-123",
             "SECRET_KEY": "a-secure-key-for-testing-only",
+            "JWT_SECRET_KEY": "a-secure-jwt-key-for-testing-only",
             "MONGO_URI": "mongodb://localhost:27017/",
             "DB_NAME": "test_database",
             "COLLECTION_NAME": "test_books",
@@ -150,7 +152,7 @@ def mock_user_data():
     hashed_password = bcrypt.generate_password_hash(PLAIN_PASSWORD).decode("utf-8")
 
     return {
-        "_id": TEST_USER_ID,
+        "_id": ObjectId(TEST_USER_ID),
         "email": "testuser@example.com",
         "password": hashed_password,
     }
@@ -172,6 +174,10 @@ def seeded_user_in_db(
     with test_app.app_context():
         mongo.db.users.insert_one(mock_user_data)
 
-    # yield the user data in case a test needs it
-    # but often we just need the side-effect of the user being in the DB
-    yield mock_user_data
+    # When yeilding the mock data back to the test,
+    # we must convert it back the ObjectId back to the string,
+    # becasue that's what 'auth_token' fixture expects to put into the JWT 'sub' claim
+    yield_data = mock_user_data.copy()
+    yield_data["_id"] = str(yield_data["_id"])
+
+    yield yield_data

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,11 +5,11 @@ A configuration file for pytest.
 This file contains shared fixtures and helpers that are automatically discovered by pytest and made available to all tests.
 """
 from unittest.mock import patch
-from bson.objectid import ObjectId
 
 import bcrypt
 import mongomock
 import pytest
+from bson.objectid import ObjectId
 
 from app import create_app
 from app.datastore.mongo_db import get_book_collection

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -185,7 +185,7 @@ def test_login_user_returns_jwt_for_valid_credentials(
     with test_app.app_context():
         # check token: we need the SECRET_KEY from the app config to decode it.
         payload = jwt.decode(
-            data["token"], test_app.config["SECRET_KEY"], algorithms=["HS256"]
+            data["token"], test_app.config["JWT_SECRET_KEY"], algorithms=["HS256"]
         )
         assert payload["sub"] == TEST_USER_ID
 

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -4,7 +4,8 @@ from unittest.mock import patch
 
 import jwt
 import pytest
-from conftest import PLAIN_PASSWORD, TEST_USER_ID # pylint: disable=import-error
+from conftest import (PLAIN_PASSWORD,  # pylint: disable=import-error
+                      TEST_USER_ID)
 
 from app import bcrypt, mongo
 

--- a/tests/test_reservations.py
+++ b/tests/test_reservations.py
@@ -1,3 +1,4 @@
+# pylint: disable=redefined-outer-name
 """..."""
 
 import pytest
@@ -28,6 +29,28 @@ def client_with_book(test_app):
         mongo.db.reservations.delete_many({})
 
 
+@pytest.mark.parametrize("payload, expected_message",
+    [
+        ("invalid!!", "Invalid Book ID"),
+        ("", "Book ID is required")
+    ]
+)
+def test_reservation_with_missing_or_invalid_book_id(payload, expected_message, client_with_book):
+    """
+    GIVEN a Flask app with a pre-existing book in the mock DB
+    WHEN a POST request is made to /books/<book_id>/reservations without a book_id_str argument
+    THEN a 400 status code is returned.
+    """
+    _ = client_with_book
+
+    # Act
+    response = client_with_book.post(
+        f'/books/{payload}/reservations',
+        json={"forenames": "Firstname", "surname": "Tester"}
+    )
+    assert response.status_code == 400
+    data = response.get_json()
+    assert data["error"] == expected_message
 
 def test_create_reservation_success(client_with_book):
     """

--- a/tests/test_reservations.py
+++ b/tests/test_reservations.py
@@ -1,0 +1,28 @@
+"""..."""
+
+import pytest
+from bson.objectid import ObjectId
+from app.extensions import mongo
+
+@pytest.fixture
+def client_with_book(test_app):
+    """
+    Provides a test client,
+    sets up the DB and
+    ensures the database is clean and
+    seeded with a single book for reservation tests.
+    """
+    with test_app.app_context():
+        mongo.db.books.delete_many({})
+        mongo.db.reservations.delete_many({})
+        mongo.db.books.insert_one({
+            "_id": ObjectId("5f8f8b8b8b8b8b8b8b8b8b8b"),
+            "title": "Test Book"
+        })
+
+    yield test_app.test_client()
+
+    # Teardown: Clean up the database
+    with test_app.app_context():
+        mongo.db.books.delete_many({})
+        mongo.db.reservations.delete_many({})

--- a/tests/test_reservations.py
+++ b/tests/test_reservations.py
@@ -32,10 +32,9 @@ def client_with_book(test_app):
 @pytest.mark.parametrize("payload, expected_message",
     [
         ("invalid!!", "Invalid Book ID"),
-        ("", "Book ID is required")
     ]
 )
-def test_reservation_with_missing_or_invalid_book_id(payload, expected_message, client_with_book):
+def test_reservation_with_invalid_book_id(payload, expected_message, client_with_book):
     """
     GIVEN a Flask app with a pre-existing book in the mock DB
     WHEN a POST request is made to /books/<book_id>/reservations without a book_id_str argument
@@ -51,24 +50,3 @@ def test_reservation_with_missing_or_invalid_book_id(payload, expected_message, 
     assert response.status_code == 400
     data = response.get_json()
     assert data["error"] == expected_message
-
-def test_create_reservation_success(client_with_book):
-    """
-    GIVEN a Flask app with a pre-existing book in the mock DB
-    WHEN a POST request is made to /books/<book_id>/reservations with valid data
-    THEN a 201 status code is returned with the new reservation data
-    """
-    _ = client_with_book
-    # Arrange
-    book_id = "5f8f8b8b8b8b8b8b8b8b8b8b"
-
-    # Act
-    response = client_with_book.post(
-        f'/books/{book_id}/reservations',
-        json={"forenames": "Firstname", "surname": "Tester"}
-    )
-    assert response.status_code == 201
-    data = response.get_json()
-    assert data['state'] == 'reserved'
-    assert data['user']['forenames'] == ['Firstname']
-    assert data['user']['surname'] == ['Tester']

--- a/tests/test_reservations.py
+++ b/tests/test_reservations.py
@@ -40,7 +40,7 @@ def auth_token(client_with_book):
     """
     # Section 1: Get the app context and secret key
     app = client_with_book.application
-    secret_key = app.config.get('SECRET_KEY', 'default-secret-key-for-dev') 
+    secret_key = app.config.get('SECRET_KEY', 'default-secret-key-for-dev')
 
     # Section 2: Define the token's payload
     # This payload should mimic what your real login endpoint would create.
@@ -70,7 +70,12 @@ def auth_token(client_with_book):
         ("invalid!!", "Invalid Book ID"),
     ]
 )
-def test_reservation_with_invalid_book_id(payload, expected_message, client_with_book):
+def test_reservation_with_invalid_book_id(
+    payload,
+    expected_message,
+    client_with_book,
+    auth_token
+    ):
     """
     GIVEN a Flask app with a pre-existing book in the mock DB
     WHEN a POST request is made to /books/<book_id>/reservations without a book_id_str argument
@@ -82,6 +87,7 @@ def test_reservation_with_invalid_book_id(payload, expected_message, client_with
     response = client_with_book.post(
         f'/books/{payload}/reservations',
         json={"forenames": "Firstname", "surname": "Tester"},
+        headers=auth_token
 
     )
     assert response.status_code == 400
@@ -101,7 +107,8 @@ def test_create_reservation_with_bad_payload(
     test_case,
     expected_status,
     expected_message,
-    client_with_book
+    client_with_book,
+    auth_token
 ):
     """
     GIVEN a Flask app with a pre-existing book

--- a/tests/test_reservations.py
+++ b/tests/test_reservations.py
@@ -122,85 +122,25 @@ def test_reservation_for_nonexistant_book(
     assert data["error"] == "Book not found"
 
 
-# def test_create_reservation_success(client_with_book, auth_token, seeded_user_in_db):
-#     """
-#     GIVEN a Flask app with a pre-existing book in the mock DB
-#     WHEN a POST request is made to /books/<book_id>/reservations with valid data
-#     THEN a 201 status code is returned with the new reservation data
-#     """
-#     _ = client_with_book
-#     # Arrange
-#     book_id = "5f8f8b8b8b8b8b8b8b8b8b8b"
+def test_create_reservation_success(client_with_book, auth_token, seeded_user_in_db):
+    """
+    GIVEN a Flask app with a pre-existing book in the mock DB
+    WHEN a POST request is made to /books/<book_id>/reservations with valid data
+    THEN a 201 status code is returned with the new reservation data
+    """
+    _ = client_with_book
+    # Arrange
+    book_id = "5f8f8b8b8b8b8b8b8b8b8b8b"
+    _expected_user_id = seeded_user_in_db["_id"]
 
-#     # Act
-#     response = client_with_book.post(
-#         f'/books/{book_id}/reservations',
-#         json={"forenames": "Firstname", "surname": "Tester"}
-#     )
-#     assert response.status_code == 201
-#     data = response.get_json()
-#     assert data['state'] == 'reserved'
-#     assert data['user']['forenames'] == 'Firstname'
-#     assert data['user']['surname'] == 'Tester'
+    # Act- make an authenticated request
+    response = client_with_book.post(
+        f'/books/{book_id}/reservations',
+        headers=auth_token,
+        json={}
+    )
 
-
-# FORENAMES_ERROR = "forenames is required and must be a string"
-# SURNAME_ERROR = "surname is required and must be a string"
-# @pytest.mark.parametrize("_test_name, payload, expected_messages",
-#     [
-#         (
-#             "forename is missing",
-#             {"surname": "Tester"},
-#             {"forenames": FORENAMES_ERROR}
-#         ),
-#         (
-#             "surname is missing",
-#             {"forenames": "John"},
-#             {"surname": SURNAME_ERROR}
-#         ),
-#         (
-#             "forename is wrong type (integer)",
-#             {"forenames": 12345, "surname": "Tester"},
-#             {"forenames": FORENAMES_ERROR}
-#         ),
-#         (
-#             "surname is wrong type (list)",
-#             {"forenames": "John", "surname": ["Doe"]},
-#             {"surname": SURNAME_ERROR}
-#         ),
-#         (
-#             "both fields are missing",
-#             {"some_other_field": "irrelevant"},
-#             {"forenames": FORENAMES_ERROR, "surname": SURNAME_ERROR}
-#         ),
-#         (
-#             "both fields are wrong type",
-#             {"forenames": None, "surname": True},
-#             {"forenames": FORENAMES_ERROR, "surname": SURNAME_ERROR}
-#         )
-#     ]
-# )
-# def test_create_reservation_with_invalid_data_fields(
-#     _test_name,
-#     payload,
-#     expected_messages,
-#     client_with_book
-# ):
-#     """
-#     GIVEN a Flask app with a pre-existing book
-#     WHEN a POST request is made with missing or malformed data fields
-#     THEN a 400 status code is returned with a specific validation error message.
-#     """
-#     _ = client_with_book
-#     book_id = "5f8f8b8b8b8b8b8b8b8b8b8b"
-#     url = f'/books/{book_id}/reservations'
-
-#     # Act: Send the invalid payload to the endpoint
-#     response = client_with_book.post(url, json=payload)
-
-#     # Assert
-#     assert response.status_code == 400
-#     data = response.get_json()
-#     # Check the overall error structure
-#     assert data["error"] == "Validation failed"
-#     assert data["messages"] == expected_messages
+    # Assert
+    data = response.get_json()
+    assert response.status_code == 201, f"Expected 201, got {response.status_code} with data: {data}" # pylint disable=line-too-long
+    assert data['state'] == 'reserved'

--- a/tests/test_reservations.py
+++ b/tests/test_reservations.py
@@ -152,7 +152,7 @@ def test_create_reservation_for_already_reserved_book_fails(
     _ = client_with_book
     _ = seeded_user_in_db
     book_id = "5f8f8b8b8b8b8b8b8b8b8b8b"
-    url = f'/books/{book_id}/reservations'
+    url = f"/books/{book_id}/reservations"
 
     # Arrange: Create the first reservation
     response1 = client_with_book.post(url, headers=auth_token, json={})
@@ -164,4 +164,4 @@ def test_create_reservation_for_already_reserved_book_fails(
     # Assert
     assert response2.status_code == 409
     data = response2.get_json()
-    assert data['error'] == "You have already reserved this book"
+    assert data["error"] == "You have already reserved this book"

--- a/tests/test_reservations.py
+++ b/tests/test_reservations.py
@@ -50,3 +50,21 @@ def test_reservation_with_invalid_book_id(payload, expected_message, client_with
     assert response.status_code == 400
     data = response.get_json()
     assert data["error"] == expected_message
+
+def test_reservation_for_nonexistant_book(client_with_book):
+    """
+    GIVEN a FLASK APP WITH A PRE-EXISTING BOOK
+    WHEN a POST request is made with a valid but non-existent book ID
+    THEN a 404 Not Found statu sis returned
+    """
+    _ = client_with_book
+    non_existent_id = ObjectId()
+
+    response = client_with_book.post(
+        f'/books/{non_existent_id}/reservations',
+        json={"forenames": "Firstname", "surname": "Tester"}
+    )
+
+    assert response.status_code == 404
+    data = response.get_json()
+    assert data is not None

--- a/tests/test_reservations.py
+++ b/tests/test_reservations.py
@@ -139,3 +139,65 @@ def test_create_reservation_success(client_with_book):
     assert data['state'] == 'reserved'
     assert data['user']['forenames'] == 'Firstname'
     assert data['user']['surname'] == 'Tester'
+
+
+FORENAMES_ERROR = "forenames is required and must be a string"
+SURNAME_ERROR = "surname is required and must be a string"
+@pytest.mark.parametrize("_test_name, payload, expected_messages",
+    [
+        (
+            "forename is missing",
+            {"surname": "Tester"},
+            {"forenames": FORENAMES_ERROR}
+        ),
+        (
+            "surname is missing",
+            {"forenames": "John"},
+            {"surname": SURNAME_ERROR}
+        ),
+        (
+            "forename is wrong type (integer)",
+            {"forenames": 12345, "surname": "Tester"},
+            {"forenames": FORENAMES_ERROR}
+        ),
+        (
+            "surname is wrong type (list)",
+            {"forenames": "John", "surname": ["Doe"]},
+            {"surname": SURNAME_ERROR}
+        ),
+        (
+            "both fields are missing",
+            {"some_other_field": "irrelevant"},
+            {"forenames": FORENAMES_ERROR, "surname": SURNAME_ERROR}
+        ),
+        (
+            "both fields are wrong type",
+            {"forenames": None, "surname": True},
+            {"forenames": FORENAMES_ERROR, "surname": SURNAME_ERROR}
+        )
+    ]
+)
+def test_create_reservation_with_invalid_data_fields(
+    _test_name,
+    payload,
+    expected_messages,
+    client_with_book
+):
+    """
+    GIVEN a Flask app with a pre-existing book
+    WHEN a POST request is made with missing or malformed data fields
+    THEN a 400 status code is returned with a specific validation error message.
+    """
+    _ = client_with_book
+    book_id = "5f8f8b8b8b8b8b8b8b8b8b8b"
+    url = f'/books/{book_id}/reservations'
+
+    # Act: Send the invalid payload to the endpoint
+    response = client_with_book.post(url, json=payload)
+
+    # Assert
+    assert response.status_code == 400
+    data = response.get_json()
+    # Check the overall error structure
+    assert data["error"] == "Validation failed"
+    assert data["messages"] == expected_messages

--- a/tests/test_reservations.py
+++ b/tests/test_reservations.py
@@ -51,6 +51,56 @@ def test_reservation_with_invalid_book_id(payload, expected_message, client_with
     data = response.get_json()
     assert data["error"] == expected_message
 
+@pytest.mark.parametrize("test_case, expected_status, expected_message",
+    [
+        ("no_payload", 415, "Unsupported Media Type"),
+        ("empty_json_object", 400, "Request body must be a non-empty JSON object"),
+        ("null_payload", 400, "Request body must be a non-empty JSON object"),
+        ("invalid_json", 400, "Invalid JSON format"),
+        ("invalid_json", 400, "Invalid JSON format"),
+    ]
+)
+def test_create_reservation_with_bad_payload(
+    test_case,
+    expected_status,
+    expected_message,
+    client_with_book
+):
+    """
+    GIVEN a Flask app with a pre-existing book
+    WHEN a POST request is made with no payload, an empty payload, a null payload, or invalid JSON
+    THEN the correct error status code and message are returned.
+    """
+    _ = client_with_book
+    book_id = "5f8f8b8b8b8b8b8b8b8b8b8b"
+    url = f'/books/{book_id}/reservations'
+
+    # Act
+    if test_case == "no_payload":
+        response = client_with_book.post(url)
+    elif test_case == "empty_json_object":
+        response = client_with_book.post(url, json={})
+    elif test_case == "null_payload":
+        response = client_with_book.post(url, data='null', content_type='application/json')
+    elif test_case == "invalid_json":
+        response = client_with_book.post(
+            url,
+            data='{ "bad" json }',
+            content_type='application/json'
+        )
+
+    # Assert
+    assert response.status_code == expected_status # pylint: disable=possibly-used-before-assignment
+
+    data = response.get_json()
+    if response.status_code == 415:
+        # Flask's default 415 error message uses a 'name' field
+        assert data["error"]["name"] == expected_message
+    else:
+        error_message = data.get("message") or data.get("error")
+        assert error_message == expected_message
+
+
 def test_reservation_for_nonexistant_book(client_with_book):
     """
     GIVEN a FLASK APP WITH A PRE-EXISTING BOOK

--- a/tests/test_reservations.py
+++ b/tests/test_reservations.py
@@ -26,3 +26,26 @@ def client_with_book(test_app):
     with test_app.app_context():
         mongo.db.books.delete_many({})
         mongo.db.reservations.delete_many({})
+
+
+
+def test_create_reservation_success(client_with_book):
+    """
+    GIVEN a Flask app with a pre-existing book in the mock DB
+    WHEN a POST request is made to /books/<book_id>/reservations with valid data
+    THEN a 201 status code is returned with the new reservation data
+    """
+    _ = client_with_book
+    # Arrange
+    book_id = "5f8f8b8b8b8b8b8b8b8b8b8b"
+
+    # Act
+    response = client_with_book.post(
+        f'/books/{book_id}/reservations',
+        json={"forenames": "Firstname", "surname": "Tester"}
+    )
+    assert response.status_code == 201
+    data = response.get_json()
+    assert data['state'] == 'reserved'
+    assert data['user']['forenames'] == ['Firstname']
+    assert data['user']['surname'] == ['Tester']

--- a/tests/test_reservations.py
+++ b/tests/test_reservations.py
@@ -68,3 +68,24 @@ def test_reservation_for_nonexistant_book(client_with_book):
     assert response.status_code == 404
     data = response.get_json()
     assert data is not None
+
+def test_create_reservation_success(client_with_book):
+    """
+    GIVEN a Flask app with a pre-existing book in the mock DB
+    WHEN a POST request is made to /books/<book_id>/reservations with valid data
+    THEN a 201 status code is returned with the new reservation data
+    """
+    _ = client_with_book
+    # Arrange
+    book_id = "5f8f8b8b8b8b8b8b8b8b8b8b"
+
+    # Act
+    response = client_with_book.post(
+        f'/books/{book_id}/reservations',
+        json={"forenames": "Firstname", "surname": "Tester"}
+    )
+    assert response.status_code == 201
+    data = response.get_json()
+    assert data['state'] == 'reserved'
+    assert data['user']['forenames'] == 'Firstname'
+    assert data['user']['surname'] == 'Tester'

--- a/tests/test_reservations.py
+++ b/tests/test_reservations.py
@@ -1,5 +1,10 @@
 # pylint: disable=redefined-outer-name
-"""..."""
+"""
+This module contains tests for the reservation functionality of the application,
+including setup fixtures and test cases for creating, validating, and handling reservations.
+Fixtures provide a clean database state and authentication for each test.
+"""
+
 from datetime import datetime, timedelta, timezone
 
 import jwt
@@ -47,7 +52,7 @@ def auth_token(client_with_book, seeded_user_in_db):
     secret_key = app.config.get("JWT_SECRET_KEY")
 
     # Section 2: Define the token's payload
-    # Use the ID from the user seeded into the databse by the fixture
+    # Use the ID from the user seeded into the database by the fixture
     fake_user_id = seeded_user_in_db["_id"]
     payload = {
         "sub": fake_user_id,
@@ -102,7 +107,7 @@ def test_reservation_for_nonexistant_book(
     """
     GIVEN a FLASK APP WITH A PRE-EXISTING BOOK
     WHEN a POST request is made with a valid but non-existent book ID
-    THEN a 404 Not Found statu sis returned
+    THEN a 404 Not Found status is returned
     """
     _ = client_with_book
     _ = seeded_user_in_db
@@ -146,7 +151,7 @@ def test_create_reservation_for_already_reserved_book_fails(
 ):
     """
     GIVEN a user who already reserved a specific book
-    WHEN they attempy to reserve that same book again
+    WHEN they attempt to reserve that same book again
     THEN a 409 Conflict status is returned.
     """
     _ = client_with_book

--- a/tests/test_reservations.py
+++ b/tests/test_reservations.py
@@ -142,5 +142,5 @@ def test_create_reservation_success(client_with_book, auth_token, seeded_user_in
 
     # Assert
     data = response.get_json()
-    assert response.status_code == 201, f"Expected 201, got {response.status_code} with data: {data}" # pylint disable=line-too-long
+    assert response.status_code == 201, f"Expected 201, got {response.status_code} with data: {data}" # pylint: disable=line-too-long
     assert data['state'] == 'reserved'


### PR DESCRIPTION
## Description

### Summary:
Adds POST /books/{book_id}/reservations to allow authenticated users to create reservations. The route is protected by require_jwt and prevents duplicate reservations by the same user.

### Key Changes:

- New JWT-protected reservation creation endpoint with duplicate prevention
- JWT configuration separation from general Flask SECRET_KEY
- Updated OpenAPI specification to reflect JWT protection requirements


### Follow-up:
- Add TTL for reservations.
- Consider adding a DB-level uniqueness constraint to guard against race conditions.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## How Has This Been Tested?

- Unit & integration tests: /tests/test_reservations.py, updated tests/test_decorators.py, tests/test_auth.py
- Manual checks: cURL requests, mongosh
- editor.swagger.io to check openapi.yml
- CI/CD - 100% test coverage and 100% pylint 


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] **My individual commit messages are descriptive and follow our [commit guidelines](https://martijnhols.nl/blog/how-to-write-a-good-git-commit-message/)**
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
