### PR TITLE
Add pagination with offset and limit to GET /books

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,3 +1,7 @@
+[run]
+omit =
+    */conftest.py
+
 [report]
 # Exclude lines from coverage report
 exclude_lines =

--- a/app/routes/legacy_routes.py
+++ b/app/routes/legacy_routes.py
@@ -10,7 +10,8 @@ from app.datastore.mongo_helper import (delete_book_by_id,
                                         insert_book_to_mongo,
                                         replace_book_by_id,
                                         validate_book_put_payload)
-from app.services.book_service import fetch_active_books, format_books_for_api, count_active_books
+from app.services.book_service import (count_active_books, fetch_active_books,
+                                       format_books_for_api)
 from app.utils.api_security import require_api_key
 from app.utils.helper import append_hostname
 
@@ -160,9 +161,7 @@ def register_legacy_routes(app):  # pylint: disable=too-many-statements
             return jsonify({"error": error}), 500
 
         return (
-            jsonify(
-                {"total_count": total_count, "items": all_formatted_books}
-            ),
+            jsonify({"total_count": total_count, "items": all_formatted_books}),
             200,
         )
 

--- a/app/routes/legacy_routes.py
+++ b/app/routes/legacy_routes.py
@@ -105,16 +105,28 @@ def register_legacy_routes(app):  # pylint: disable=too-many-statements
         including the total count.
         """
         # --- 1. Get and Validate Query Parameters ---
-        offset_str = request.args.get('offset', '0') # 0 is default
-        limit_str = request.args.get('limit', '20') # 20 is default
+        offset_str = request.args.get("offset", "0")  # 0 is default
+        limit_str = request.args.get("limit", "20")  # 20 is default
         try:
             offset = int(offset_str)
             limit = int(limit_str)
         except ValueError:
-            return jsonify({"error": "Query parameters 'limit' and 'offset' must be integers."}), 400 # pylint: disable=line-too-long
+            return (
+                jsonify(
+                    {"error": "Query parameters 'limit' and 'offset' must be integers."}
+                ),
+                400,
+            )  # pylint: disable=line-too-long
 
         if offset < 0 or limit < 0:
-            return jsonify({"error": "Query parameters 'limit' and 'offset' cannot be negative."}), 400 # pylint: disable=line-too-long
+            return (
+                jsonify(
+                    {
+                        "error": "Query parameters 'limit' and 'offset' cannot be negative."
+                    }
+                ),
+                400,
+            )  # pylint: disable=line-too-long
 
         # --- 2. Call the Service Layer to Fetch Data ---
         try:

--- a/app/routes/legacy_routes.py
+++ b/app/routes/legacy_routes.py
@@ -148,8 +148,7 @@ def register_legacy_routes(app):  # pylint: disable=too-many-statements
 
             return jsonify(error_payload), 503
 
-        if not raw_books:
-            return jsonify({"error": "No books found"}), 404
+        # --- 3. Format and Return the Response ---
 
         # extract host from the request
         host = request.host_url.rstrip("/")
@@ -162,7 +161,7 @@ def register_legacy_routes(app):  # pylint: disable=too-many-statements
 
         return (
             jsonify(
-                {"total_count": len(all_formatted_books), "items": all_formatted_books}
+                {"total_count": total_count, "items": all_formatted_books}
             ),
             200,
         )

--- a/app/routes/legacy_routes.py
+++ b/app/routes/legacy_routes.py
@@ -104,6 +104,19 @@ def register_legacy_routes(app):  # pylint: disable=too-many-statements
         return them in a JSON response
         including the total count.
         """
+        # --- 1. Get and Validate Query Parameters ---
+        offset_str = request.args.get('offset', '0') # 0 is default
+        limit_str = request.args.get('limit', '20') # 20 is default
+        try:
+            offset = int(offset_str)
+            limit = int(limit_str)
+        except ValueError:
+            return jsonify({"error": "Query parameters 'limit' and 'offset' must be integers."}), 400 # pylint: disable=line-too-long
+
+        if offset < 0 or limit < 0:
+            return jsonify({"error": "Query parameters 'limit' and 'offset' cannot be negative."}), 400 # pylint: disable=line-too-long
+
+        # --- 2. Call the Service Layer to Fetch Data ---
         try:
             raw_books = fetch_active_books()
         except ConnectionFailure:

--- a/app/routes/legacy_routes.py
+++ b/app/routes/legacy_routes.py
@@ -10,7 +10,7 @@ from app.datastore.mongo_helper import (delete_book_by_id,
                                         insert_book_to_mongo,
                                         replace_book_by_id,
                                         validate_book_put_payload)
-from app.services.book_service import fetch_active_books, format_books_for_api
+from app.services.book_service import fetch_active_books, format_books_for_api, count_active_books
 from app.utils.api_security import require_api_key
 from app.utils.helper import append_hostname
 
@@ -129,8 +129,14 @@ def register_legacy_routes(app):  # pylint: disable=too-many-statements
             )  # pylint: disable=line-too-long
 
         # --- 2. Call the Service Layer to Fetch Data ---
+
         try:
-            raw_books = fetch_active_books()
+            # Get total count for the response metadata
+            total_count = count_active_books()
+
+            # Next, get a paginated list of documents
+            raw_books = fetch_active_books(offset=offset, limit=limit)
+
         except ConnectionFailure:
             error_payload = {
                 "error": {

--- a/app/services/book_service.py
+++ b/app/services/book_service.py
@@ -10,7 +10,6 @@ def count_active_books():
     """
     query_filter = {"state": {"$ne": "deleted"}}
     count = mongo.db.books.count_documents(query_filter)
-    print("count: ", count)
 
     return count
 

--- a/app/services/book_service.py
+++ b/app/services/book_service.py
@@ -4,13 +4,22 @@ from app.extensions import mongo
 from app.utils.helper import append_hostname
 
 
+def count_active_books():
+    """
+    Counts the total number of active books in the database.
+    """
+    query_filter = {"state": {"$ne": "deleted"}}
+    count = mongo.db.books.count_documents(query_filter)
+    print("count: ", count)
+
+    return count
+
+
 def fetch_active_books(offset: int = 0, limit: int = 20):
     """
     Fetches a paginated list of all active (non-deleted) books from the database.
     """
-
     query_filter = {"state": {"$ne": "deleted"}}  # Only non-deleted books
-
     cursor = mongo.db.books.find(query_filter).skip(offset).limit(limit)
 
     return list(cursor)

--- a/app/services/book_service.py
+++ b/app/services/book_service.py
@@ -1,20 +1,20 @@
 """Service layer for handling book-related operations."""
 
-from app.datastore.mongo_db import get_book_collection
-from app.datastore.mongo_helper import find_books
+# from app.datastore.mongo_db import get_book_collection
+# from app.datastore.mongo_helper import find_books
+from app.extensions import mongo
 from app.utils.helper import append_hostname
 
 
-def fetch_active_books():
+def fetch_active_books(offset: int = 0, limit: int =20):
     """
-    Fetches a cursor for all non-deleted books from the database.
-    Returns a Python list.
+    Fetches a paginated list of all active (non-deleted) books from the database.
     """
 
-    collection = get_book_collection()
     query_filter = {"state": {"$ne": "deleted"}}  # Only non-deleted books
 
-    cursor = find_books(collection, query_filter=query_filter)
+    cursor = mongo.db.books.find(query_filter).skip(offset).limit(limit)
+
     return list(cursor)
 
 

--- a/app/services/book_service.py
+++ b/app/services/book_service.py
@@ -1,12 +1,10 @@
 """Service layer for handling book-related operations."""
 
-# from app.datastore.mongo_db import get_book_collection
-# from app.datastore.mongo_helper import find_books
 from app.extensions import mongo
 from app.utils.helper import append_hostname
 
 
-def fetch_active_books(offset: int = 0, limit: int =20):
+def fetch_active_books(offset: int = 0, limit: int = 20):
     """
     Fetches a paginated list of all active (non-deleted) books from the database.
     """

--- a/openapi.yml
+++ b/openapi.yml
@@ -409,6 +409,28 @@ paths:
       summary: Returns all books in the database
       description: Retrieve all books from the database and return them in a JSON response including the total count.
       operationId: getAllBooks
+      parameters:
+        - name: offset
+          in: query
+          description: The number of items to skip before starting to collect the result set.
+          required: false
+          schema:
+            type: integer
+            format: int32
+            default: 0
+            minimum: 0
+            example: 20
+        - name: limit
+          in: query
+          description: The number of items to return.
+          required: false
+          schema:
+            type: integer
+            format: int32
+            default: 20
+            minimum: 1
+            maximum: 100
+            example: 10
       responses:
         '200':
           description: A list of all books including the total count.
@@ -416,6 +438,14 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/BookListResponse'
+        '400':
+          description: Invalid query parameters provided.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SimpleError'
+              example:
+                error: "Query parameters 'limit' and 'offset' cannot be negative."
         '404':
           $ref: '#/components/responses/NotFound' 
         '500':

--- a/run_pylint.sh
+++ b/run_pylint.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Run pylint on the folder ignoring virtual environment folder
-pylint --ignore=venv .
+pylint --ignore=venv,.venv .
 # Check the exit code to determine if Pylint passed or failed
 if [ $? -eq 0 ]; then
     echo "Pylint passed successfully on all files."

--- a/scripts/seed_reservations.py
+++ b/scripts/seed_reservations.py
@@ -49,7 +49,7 @@ def run_reservation_population():
         - Inserts new reservations or updates existing ones based on the data.
         - Handles errors related to database access and data loading.
     Returns:
-        tuple or Response: 
+        tuple or Response:
             - On success or handled error, returns a tuple (success: bool, message: str).
             - If required collections cannot be loaded, returns a Flask Response and status code.
     Exceptions:
@@ -143,10 +143,12 @@ def run_reservation_population():
 
 
 if __name__ == "__main__":
-    from app import create_app  # Import the create_app function from your app module
+    from app import \
+        create_app  # Import the create_app function from your app module
+
     app = create_app()  # create the Flask app
     with app.app_context():  # activate app context
         success, message = run_reservation_population()
         print(message)
         if not success:
-            sys.exit(1) # Exit with an error code if something failed
+            sys.exit(1)  # Exit with an error code if something failed

--- a/scripts/test_data/sample_books.json
+++ b/scripts/test_data/sample_books.json
@@ -238,5 +238,245 @@
       "reviews": "/books/550e8400-e29b-41d4-a716-446655440013/reviews"
     },
     "state": "active"
+  },
+  {
+    "id": "550e8400-e29b-41d4-a716-446655440014",
+    "title": "The Iliad",
+    "synopsis": "An ancient epic poem recounting the events of the Trojan War and the wrath of Achilles.",
+    "author": "Homer",
+    "links": {
+      "self": "/books/550e8400-e29b-41d4-a716-446655440014",
+      "reservations": "/books/550e8400-e29b-41d4-a716-446655440014/reservations",
+      "reviews": "/books/550e8400-e29b-41d4-a716-446655440014/reviews"
+    },
+    "state": "active"
+  },
+  {
+    "id": "550e8400-e29b-41d4-a716-446655440015",
+    "title": "Great Expectations",
+    "synopsis": "The coming-of-age story of Pip and his growth amid wealth, class, and personal expectations.",
+    "author": "Charles Dickens",
+    "links": {
+      "self": "/books/550e8400-e29b-41d4-a716-446655440015",
+      "reservations": "/books/550e8400-e29b-41d4-a716-446655440015/reservations",
+      "reviews": "/books/550e8400-e29b-41d4-a716-446655440015/reviews"
+    },
+    "state": "active"
+  },
+  {
+    "id": "550e8400-e29b-41d4-a716-446655440016",
+    "title": "A Tale of Two Cities",
+    "synopsis": "A historical novel contrasting life in London and Paris before and during the French Revolution.",
+    "author": "Charles Dickens",
+    "links": {
+      "self": "/books/550e8400-e29b-41d4-a716-446655440016",
+      "reservations": "/books/550e8400-e29b-41d4-a716-446655440016/reservations",
+      "reviews": "/books/550e8400-e29b-41d4-a716-446655440016/reviews"
+    },
+    "state": "active"
+  },
+  {
+    "id": "550e8400-e29b-41d4-a716-446655440017",
+    "title": "The Stranger",
+    "synopsis": "A novel about an emotionally detached man whose actions lead to an existential crisis.",
+    "author": "Albert Camus",
+    "links": {
+      "self": "/books/550e8400-e29b-41d4-a716-446655440017",
+      "reservations": "/books/550e8400-e29b-41d4-a716-446655440017/reservations",
+      "reviews": "/books/550e8400-e29b-41d4-a716-446655440017/reviews"
+    },
+    "state": "active"
+  },
+  {
+    "id": "550e8400-e29b-41d4-a716-446655440018",
+    "title": "One Hundred Years of Solitude",
+    "synopsis": "A multi-generational tale weaving magical realism and the history of the Buendía family.",
+    "author": "Gabriel García Márquez",
+    "links": {
+      "self": "/books/550e8400-e29b-41d4-a716-446655440018",
+      "reservations": "/books/550e8400-e29b-41d4-a716-446655440018/reservations",
+      "reviews": "/books/550e8400-e29b-41d4-a716-446655440018/reviews"
+    },
+    "state": "active"
+  },
+  {
+    "id": "550e8400-e29b-41d4-a716-446655440019",
+    "title": "Beloved",
+    "synopsis": "A powerful story of memory, trauma, and the legacy of slavery centered on a former enslaved woman.",
+    "author": "Toni Morrison",
+    "links": {
+      "self": "/books/550e8400-e29b-41d4-a716-446655440019",
+      "reservations": "/books/550e8400-e29b-41d4-a716-446655440019/reservations",
+      "reviews": "/books/550e8400-e29b-41d4-a716-446655440019/reviews"
+    },
+    "state": "active"
+  },
+  {
+    "id": "550e8400-e29b-41d4-a716-44665544001a",
+    "title": "The Road",
+    "synopsis": "A bleak, moving post-apocalyptic journey of a father and son struggling to survive.",
+    "author": "Cormac McCarthy",
+    "links": {
+      "self": "/books/550e8400-e29b-41d4-a716-44665544001a",
+      "reservations": "/books/550e8400-e29b-41d4-a716-44665544001a/reservations",
+      "reviews": "/books/550e8400-e29b-41d4-a716-44665544001a/reviews"
+    },
+    "state": "active"
+  },
+  {
+    "id": "550e8400-e29b-41d4-a716-44665544001b",
+    "title": "The Handmaid's Tale",
+    "synopsis": "A dystopian novel about a theocratic society that subjugates women and controls reproduction.",
+    "author": "Margaret Atwood",
+    "links": {
+      "self": "/books/550e8400-e29b-41d4-a716-44665544001b",
+      "reservations": "/books/550e8400-e29b-41d4-a716-44665544001b/reservations",
+      "reviews": "/books/550e8400-e29b-41d4-a716-44665544001b/reviews"
+    },
+    "state": "active"
+  },
+  {
+    "id": "550e8400-e29b-41d4-a716-44665544001c",
+    "title": "Invisible Man",
+    "synopsis": "A novel following an African American man's search for identity amid racial prejudice.",
+    "author": "Ralph Ellison",
+    "links": {
+      "self": "/books/550e8400-e29b-41d4-a716-44665544001c",
+      "reservations": "/books/550e8400-e29b-41d4-a716-44665544001c/reservations",
+      "reviews": "/books/550e8400-e29b-41d4-a716-44665544001c/reviews"
+    },
+    "state": "active"
+  },
+  {
+    "id": "550e8400-e29b-41d4-a716-44665544001d",
+    "title": "Slaughterhouse-Five",
+    "synopsis": "A darkly comic account of World War II and time travel, following Billy Pilgrim's experiences.",
+    "author": "Kurt Vonnegut",
+    "links": {
+      "self": "/books/550e8400-e29b-41d4-a716-44665544001d",
+      "reservations": "/books/550e8400-e29b-41d4-a716-44665544001d/reservations",
+      "reviews": "/books/550e8400-e29b-41d4-a716-44665544001d/reviews"
+    },
+    "state": "active"
+  },
+  {
+    "id": "550e8400-e29b-41d4-a716-44665544001e",
+    "title": "The Color Purple",
+    "synopsis": "An epistolary novel recounting the hardships and resilience of African American women in the early 20th century.",
+    "author": "Alice Walker",
+    "links": {
+      "self": "/books/550e8400-e29b-41d4-a716-44665544001e",
+      "reservations": "/books/550e8400-e29b-41d4-a716-44665544001e/reservations",
+      "reviews": "/books/550e8400-e29b-41d4-a716-44665544001e/reviews"
+    },
+    "state": "active"
+  },
+  {
+    "id": "550e8400-e29b-41d4-a716-44665544001f",
+    "title": "Don Quixote",
+    "synopsis": "A comic and tragic tale of a man who becomes a knight-errant and his misadventures across Spain.",
+    "author": "Miguel de Cervantes",
+    "links": {
+      "self": "/books/550e8400-e29b-41d4-a716-44665544001f",
+      "reservations": "/books/550e8400-e29b-41d4-a716-44665544001f/reservations",
+      "reviews": "/books/550e8400-e29b-41d4-a716-44665544001f/reviews"
+    },
+    "state": "active"
+  },
+  {
+    "id": "550e8400-e29b-41d4-a716-446655440020",
+    "title": "The Kite Runner",
+    "synopsis": "A story of friendship, betrayal, and redemption set against Afghanistan's turbulent history.",
+    "author": "Khaled Hosseini",
+    "links": {
+      "self": "/books/550e8400-e29b-41d4-a716-446655440020",
+      "reservations": "/books/550e8400-e29b-41d4-a716-446655440020/reservations",
+      "reviews": "/books/550e8400-e29b-41d4-a716-446655440020/reviews"
+    },
+    "state": "active"
+  },
+  {
+    "id": "550e8400-e29b-41d4-a716-446655440021",
+    "title": "The Alchemist",
+    "synopsis": "A philosophical fable about a shepherd's journey to discover his personal legend and purpose.",
+    "author": "Paulo Coelho",
+    "links": {
+      "self": "/books/550e8400-e29b-41d4-a716-446655440021",
+      "reservations": "/books/550e8400-e29b-41d4-a716-446655440021/reservations",
+      "reviews": "/books/550e8400-e29b-41d4-a716-446655440021/reviews"
+    },
+    "state": "active"
+  },
+  {
+    "id": "550e8400-e29b-41d4-a716-446655440022",
+    "title": "Lord of the Flies",
+    "synopsis": "A group of boys stranded on an island descend into savagery as social order collapses.",
+    "author": "William Golding",
+    "links": {
+      "self": "/books/550e8400-e29b-41d4-a716-446655440022",
+      "reservations": "/books/550e8400-e29b-41d4-a716-446655440022/reservations",
+      "reviews": "/books/550e8400-e29b-41d4-a716-446655440022/reviews"
+    },
+    "state": "active"
+  },
+  {
+    "id": "550e8400-e29b-41d4-a716-446655440023",
+    "title": "Catch-22",
+    "synopsis": "A satirical novel about the absurdities of war and the paradoxical rules that trap its characters.",
+    "author": "Joseph Heller",
+    "links": {
+      "self": "/books/550e8400-e29b-41d4-a716-446655440023",
+      "reservations": "/books/550e8400-e29b-41d4-a716-446655440023/reservations",
+      "reviews": "/books/550e8400-e29b-41d4-a716-446655440023/reviews"
+    },
+    "state": "active"
+  },
+  {
+    "id": "550e8400-e29b-41d4-a716-446655440024",
+    "title": "The Grapes of Wrath",
+    "synopsis": "A moving portrayal of a family's struggle during the Great Depression as they seek a better life.",
+    "author": "John Steinbeck",
+    "links": {
+      "self": "/books/550e8400-e29b-41d4-a716-446655440024",
+      "reservations": "/books/550e8400-e29b-41d4-a716-446655440024/reservations",
+      "reviews": "/books/550e8400-e29b-41d4-a716-446655440024/reviews"
+    },
+    "state": "active"
+  },
+  {
+    "id": "550e8400-e29b-41d4-a716-446655440025",
+    "title": "The Hitchhiker's Guide to the Galaxy",
+    "synopsis": "A comic science-fiction romp following Arthur Dent's absurd adventures through space.",
+    "author": "Douglas Adams",
+    "links": {
+      "self": "/books/550e8400-e29b-41d4-a716-446655440025",
+      "reservations": "/books/550e8400-e29b-41d4-a716-446655440025/reservations",
+      "reviews": "/books/550e8400-e29b-41d4-a716-446655440025/reviews"
+    },
+    "state": "active"
+  },
+  {
+    "id": "550e8400-e29b-41d4-a716-446655440026",
+    "title": "Fahrenheit 451",
+    "synopsis": "A dystopian novel where books are banned and 'firemen' burn any that are found.",
+    "author": "Ray Bradbury",
+    "links": {
+      "self": "/books/550e8400-e29b-41d4-a716-446655440026",
+      "reservations": "/books/550e8400-e29b-41d4-a716-446655440026/reservations",
+      "reviews": "/books/550e8400-e29b-41d4-a716-446655440026/reviews"
+    },
+    "state": "active"
+  },
+  {
+    "id": "550e8400-e29b-41d4-a716-446655440027",
+    "title": "The Old Man and the Sea",
+    "synopsis": "A short, lyrical novel about an aging fisherman's epic struggle with a giant marlin.",
+    "author": "Ernest Hemingway",
+    "links": {
+      "self": "/books/550e8400-e29b-41d4-a716-446655440027",
+      "reservations": "/books/550e8400-e29b-41d4-a716-446655440027/reservations",
+      "reviews": "/books/550e8400-e29b-41d4-a716-446655440027/reviews"
+    },
+    "state": "active"
   }
 ]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -146,6 +146,33 @@ def mongo_setup(test_app):  # pylint: disable=redefined-outer-name
         mongo.db.reservations.delete_many({})
 
 
+@pytest.fixture
+def seeded_books_in_db(test_app, mongo_setup): # pylint: disable=redefined-outer-name
+    """
+    Ensures the books collection is clean and then seeds it with 50 books
+    for pagination testting.
+    """
+    _ = mongo_setup
+
+    with test_app.app_context():
+        collection = get_book_collection()
+        books_to_insert = [
+            {
+                "_id": f"book_{i}",
+                "title": f"Test Book {i}",
+                "state": "active"
+            }
+            for i in range(50)
+        ]
+        if books_to_insert:
+            collection.insert_many(books_to_insert)
+        print("books_to_insert: ", books_to_insert)
+
+    return books_to_insert()
+
+
+
+
 TEST_USER_ID = "6154b3a3e4a5b6c7d8e9f0a1"
 PLAIN_PASSWORD = "a-secure-password"
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -147,7 +147,7 @@ def mongo_setup(test_app):  # pylint: disable=redefined-outer-name
 
 
 @pytest.fixture
-def seeded_books_in_db(test_app, mongo_setup): # pylint: disable=redefined-outer-name
+def seeded_books_in_db(test_app, mongo_setup):  # pylint: disable=redefined-outer-name
     """
     Ensures the books collection is clean and then seeds it with 50 books
     for pagination testting.
@@ -157,11 +157,7 @@ def seeded_books_in_db(test_app, mongo_setup): # pylint: disable=redefined-outer
     with test_app.app_context():
         collection = get_book_collection()
         books_to_insert = [
-            {
-                "_id": f"book_{i}",
-                "title": f"Test Book {i}",
-                "state": "active"
-            }
+            {"_id": f"book_{i}", "title": f"Test Book {i}", "state": "active"}
             for i in range(50)
         ]
         if books_to_insert:
@@ -169,8 +165,6 @@ def seeded_books_in_db(test_app, mongo_setup): # pylint: disable=redefined-outer
         print("books_to_insert: ", books_to_insert)
 
     return books_to_insert()
-
-
 
 
 TEST_USER_ID = "6154b3a3e4a5b6c7d8e9f0a1"

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,6 +1,7 @@
 # pylint: disable=missing-docstring
 
 from unittest.mock import MagicMock, patch
+
 import pytest
 from bson.objectid import ObjectId
 from pymongo.errors import ConnectionFailure
@@ -193,6 +194,7 @@ def test_500_response_is_json(client):
 
 # ------------------------ Tests for GET --------------------------------------------
 
+
 @patch("app.routes.legacy_routes.format_books_for_api")
 @patch("app.routes.legacy_routes.count_active_books")
 @patch("app.routes.legacy_routes.fetch_active_books")
@@ -230,6 +232,7 @@ def test_get_all_books_success_path(mock_fetch, mock_count, mock_format, client)
     mock_count.assert_called_once_with()
     mock_fetch.assert_called_once_with(offset=0, limit=20)
     mock_format.assert_called_once_with(mock_raw_books_from_db, "http://localhost")
+
 
 @patch("app.routes.legacy_routes.fetch_active_books")
 def test_missing_fields_in_book_object_returned_by_database(mock_fetch, client):
@@ -269,14 +272,16 @@ def test_get_books_success_default_pagination(mock_fetch, mock_count, client):
     """
     # Arrange:
     # 1. Configure the mock for fetch_active_books
-    mock_fetch.return_value = [{
-        "_id": "book1",
-        "title": "A Great Book",
-        "author": "Jane Doe",
-        "synopsis": "An amazing story.",
-        "links": {"self": "/books/book1"},
-        "state": "active",
-    }]
+    mock_fetch.return_value = [
+        {
+            "_id": "book1",
+            "title": "A Great Book",
+            "author": "Jane Doe",
+            "synopsis": "An amazing story.",
+            "links": {"self": "/books/book1"},
+            "state": "active",
+        }
+    ]
     # 2. Configure the mock for count_active_books
     mock_count.return_value = 50
 
@@ -299,12 +304,16 @@ def test_get_books_success_default_pagination(mock_fetch, mock_count, client):
     assert "state" not in json_data["items"][0]
 
 
-@pytest.mark.parametrize("function_to_patch, _scenario_id", [
-    ("app.routes.legacy_routes.count_active_books", "count_fails"),
-    ("app.routes.legacy_routes.fetch_active_books", "fetch_fails")
-    ]
+@pytest.mark.parametrize(
+    "function_to_patch, _scenario_id",
+    [
+        ("app.routes.legacy_routes.count_active_books", "count_fails"),
+        ("app.routes.legacy_routes.fetch_active_books", "fetch_fails"),
+    ],
 )
-def test_get_books_handles_database_connection_error(function_to_patch, _scenario_id, client):
+def test_get_books_handles_database_connection_error(
+    function_to_patch, _scenario_id, client
+):
     """
     GIVEN the database connection fails during either the count or fetch call
     WHEN the /books endpoint is called
@@ -323,8 +332,10 @@ def test_get_books_handles_database_connection_error(function_to_patch, _scenari
 
     assert "error" in json_data
     assert json_data["error"]["code"] == 503
-    assert "The database service is temporarily unavailable" in json_data["error"]["message"]
-
+    assert (
+        "The database service is temporarily unavailable"
+        in json_data["error"]["message"]
+    )
 
 
 # -------- Tests for GET a single resource ----------------

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -258,24 +258,6 @@ def test_missing_fields_in_book_object_returned_by_database(mock_fetch, client):
     mock_fetch.assert_called_once()
 
 
-@patch("app.routes.legacy_routes.fetch_active_books")
-def test_get_all_books_returns_error_404_when_list_is_empty(mock_fetch, client):
-    empty_data = []
-    mock_fetch.return_value = empty_data
-    response = client.get("/books")
-    assert response.status_code == 404
-    assert "No books found" in response.get_json()["error"]
-
-
-@patch("app.routes.legacy_routes.fetch_active_books")
-def test_get_book_returns_404_when_books_is_none(mock_fetch, client):
-    none_data = None
-    mock_fetch.return_value = none_data
-    response = client.get("/books")
-    assert response.status_code == 404
-    assert "No books found" in response.get_json()["error"]
-
-
 @patch("app.routes.legacy_routes.count_active_books")
 @patch("app.routes.legacy_routes.fetch_active_books")
 def test_get_books_success_default_pagination(mock_fetch, mock_count, client):

--- a/tests/test_app_utils_helper.py
+++ b/tests/test_app_utils_helper.py
@@ -107,9 +107,12 @@ def test_add_book_response_contains_absolute_urls(client, monkeypatch):
 #         assert book["links"]["reviews"].startswith("http://localhost")
 #         assert book["links"]["self"].endswith(f"books/{new_book_id}")
 
+
 @patch("app.routes.legacy_routes.count_active_books")
 @patch("app.routes.legacy_routes.fetch_active_books")
-def test_get_books_correctly_formats_links_with_hostname(mock_fetch, mock_count, client):
+def test_get_books_correctly_formats_links_with_hostname(
+    mock_fetch, mock_count, client
+):
     """
     GIVEN a mocked database that returns raw book data with relative links
     WHEN the /books endpoint is called
@@ -117,17 +120,19 @@ def test_get_books_correctly_formats_links_with_hostname(mock_fetch, mock_count,
     """
     # ARRANGE
     # 1. Mock the raw, unformatted data from the database
-    raw_book_data = [{
-        "_id": "123",
-        "title": "A Test Book",
-        "author": "The Tester",
-        "synopsis": "A book for testing.",
-        "links": {
-            "self": "/books/123",
-            "reservations": "/books/123/reservations",
-        },
-        "state": "active"
-    }]
+    raw_book_data = [
+        {
+            "_id": "123",
+            "title": "A Test Book",
+            "author": "The Tester",
+            "synopsis": "A book for testing.",
+            "links": {
+                "self": "/books/123",
+                "reservations": "/books/123/reservations",
+            },
+            "state": "active",
+        }
+    ]
     mock_fetch.return_value = raw_book_data
 
     # 2. Mock the total count of books
@@ -145,7 +150,10 @@ def test_get_books_correctly_formats_links_with_hostname(mock_fetch, mock_count,
     # Verify the link formatting
     formatted_book = response_data["items"][0]
     assert formatted_book["links"]["self"] == "http://localhost/books/123"
-    assert formatted_book["links"]["reservations"] == "http://localhost/books/123/reservations"
+    assert (
+        formatted_book["links"]["reservations"]
+        == "http://localhost/books/123/reservations"
+    )
 
     # Verify that the formatter did its job cleaning up
     assert "state" not in formatted_book

--- a/tests/test_app_utils_helper.py
+++ b/tests/test_app_utils_helper.py
@@ -68,23 +68,70 @@ def test_add_book_response_contains_absolute_urls(client, monkeypatch):
     assert actual_link is not None, "Response JSON must contain a 'links' object"
 
 
-@patch("app.services.book_service.find_books")
-def test_append_host_to_links_in_get(mock_find_books, client):
+# @patch("app.services.book_service.find_books")
+# def test_append_host_to_links_in_get(mock_find_books, client):
 
-    # ARRANGE: Provide sample data for the mock to return
-    mock_find_books.return_value = [
-        {
-            "_id": "123",
-            "title": "A Test Book",
-            "author": "The Tester",
-            "synopsis": "A book for testing.",
-            "links": {
-                "self": "/books/123",
-                "reservations": "/books/123",
-                "reviews": "/books/123",
-            },
-        }
-    ]
+#     # ARRANGE: Provide sample data for the mock to return
+#     mock_find_books.return_value = [
+#         {
+#             "_id": "123",
+#             "title": "A Test Book",
+#             "author": "The Tester",
+#             "synopsis": "A book for testing.",
+#             "links": {
+#                 "self": "/books/123",
+#                 "reservations": "/books/123",
+#                 "reviews": "/books/123",
+#             },
+#         }
+#     ]
+
+#     # ACT
+#     response = client.get("/books")
+#     response_data = response.get_json()
+
+#     # ASSERT
+#     assert response.status_code == 200
+
+#     book = response_data["items"][0]
+#     assert response.headers["content-type"] == "application/json"
+#     assert isinstance(response_data, dict)
+#     assert "total_count" in response_data
+#     assert "items" in response_data
+#     # response_data["items"]["links"]["self"]
+#     for book in response_data["items"]:
+#         new_book_id = book.get("id")
+#         assert book["links"]["self"].startswith("http://localhost")
+#         assert book["links"]["self"] == "http://localhost/books/123"
+#         assert book["links"]["reservations"].startswith("http://localhost")
+#         assert book["links"]["reviews"].startswith("http://localhost")
+#         assert book["links"]["self"].endswith(f"books/{new_book_id}")
+
+@patch("app.routes.legacy_routes.count_active_books")
+@patch("app.routes.legacy_routes.fetch_active_books")
+def test_get_books_correctly_formats_links_with_hostname(mock_fetch, mock_count, client):
+    """
+    GIVEN a mocked database that returns raw book data with relative links
+    WHEN the /books endpoint is called
+    THEN the final JSON response should contain absolute URLs with the correct hostname.
+    """
+    # ARRANGE
+    # 1. Mock the raw, unformatted data from the database
+    raw_book_data = [{
+        "_id": "123",
+        "title": "A Test Book",
+        "author": "The Tester",
+        "synopsis": "A book for testing.",
+        "links": {
+            "self": "/books/123",
+            "reservations": "/books/123/reservations",
+        },
+        "state": "active"
+    }]
+    mock_fetch.return_value = raw_book_data
+
+    # 2. Mock the total count of books
+    mock_count.return_value = 1
 
     # ACT
     response = client.get("/books")
@@ -92,20 +139,18 @@ def test_append_host_to_links_in_get(mock_find_books, client):
 
     # ASSERT
     assert response.status_code == 200
+    assert response_data["total_count"] == 1
+    assert len(response_data["items"]) == 1
 
-    book = response_data["items"][0]
-    assert response.headers["content-type"] == "application/json"
-    assert isinstance(response_data, dict)
-    assert "total_count" in response_data
-    assert "items" in response_data
-    # response_data["items"]["links"]["self"]
-    for book in response_data["items"]:
-        new_book_id = book.get("id")
-        assert book["links"]["self"].startswith("http://localhost")
-        assert book["links"]["self"] == "http://localhost/books/123"
-        assert book["links"]["reservations"].startswith("http://localhost")
-        assert book["links"]["reviews"].startswith("http://localhost")
-        assert book["links"]["self"].endswith(f"books/{new_book_id}")
+    # Verify the link formatting
+    formatted_book = response_data["items"][0]
+    assert formatted_book["links"]["self"] == "http://localhost/books/123"
+    assert formatted_book["links"]["reservations"] == "http://localhost/books/123/reservations"
+
+    # Verify that the formatter did its job cleaning up
+    assert "state" not in formatted_book
+    assert "_id" not in formatted_book
+    assert formatted_book["id"] == "123"
 
 
 def test_append_host_to_links_in_get_book(client, monkeypatch):

--- a/tests/test_book_service.py
+++ b/tests/test_book_service.py
@@ -25,7 +25,7 @@ def test_count_active_books_returns_correct_count(test_app):
         mock_mongo.db.books.count_documents.assert_called_once_with(expected_query)
 
 
-@patch('app.services.book_service.mongo')
+@patch("app.services.book_service.mongo")
 def test_fetch_active_books_uses_default_pagination(mock_mongo, test_app):
     """
     GIVEN no arguments are provided
@@ -48,10 +48,12 @@ def test_fetch_active_books_uses_default_pagination(mock_mongo, test_app):
     expected_filter = {"state": {"$ne": "deleted"}}
     mock_mongo.db.books.find.assert_called_once_with(expected_filter)
     mock_mongo.db.books.find.return_value.skip.assert_called_once_with(0)
-    mock_mongo.db.books.find.return_value.skip.return_value.limit.assert_called_once_with(20)
+    mock_mongo.db.books.find.return_value.skip.return_value.limit.assert_called_once_with(
+        20
+    )
 
 
-@patch('app.services.book_service.mongo')
+@patch("app.services.book_service.mongo")
 def test_fetch_active_books_uses_custom_pagination(mock_mongo, test_app):
     """
     GIVEN custom offset and limit arguments
@@ -70,4 +72,6 @@ def test_fetch_active_books_uses_custom_pagination(mock_mongo, test_app):
     expected_filter = {"state": {"$ne": "deleted"}}
     mock_mongo.db.books.find.assert_called_once_with(expected_filter)
     mock_mongo.db.books.find.return_value.skip.assert_called_once_with(10)
-    mock_mongo.db.books.find.return_value.skip.return_value.limit.assert_called_once_with(5)
+    mock_mongo.db.books.find.return_value.skip.return_value.limit.assert_called_once_with(
+        5
+    )

--- a/tests/test_book_service.py
+++ b/tests/test_book_service.py
@@ -2,7 +2,7 @@
 
 from unittest.mock import patch
 
-from app.services.book_service import count_active_books
+from app.services.book_service import count_active_books, fetch_active_books
 
 
 def test_count_active_books_returns_correct_count(test_app):
@@ -23,3 +23,51 @@ def test_count_active_books_returns_correct_count(test_app):
         assert result == 5
         expected_query = {"state": {"$ne": "deleted"}}
         mock_mongo.db.books.count_documents.assert_called_once_with(expected_query)
+
+
+@patch('app.services.book_service.mongo')
+def test_fetch_active_books_uses_default_pagination(mock_mongo, test_app):
+    """
+    GIVEN no arguments are provided
+    WHEN fetch_active_books is called
+    THEN it should query the database using the default offset (0) and limit (20).
+    """
+    mock_mongo.db.books.find.return_value.skip.return_value.limit.return_value = [
+        {"_id": "1", "title": "A Book"}
+    ]
+    with test_app.app_context():
+        # ACT: Call the function with no arguments
+        result = fetch_active_books()
+
+    # Assert
+    # 1. Check that the result is what we expect
+    assert isinstance(result, list)
+    assert len(result) == 1
+
+    # 2. Check that the database methods were called with the correct default values
+    expected_filter = {"state": {"$ne": "deleted"}}
+    mock_mongo.db.books.find.assert_called_once_with(expected_filter)
+    mock_mongo.db.books.find.return_value.skip.assert_called_once_with(0)
+    mock_mongo.db.books.find.return_value.skip.return_value.limit.assert_called_once_with(20)
+
+
+@patch('app.services.book_service.mongo')
+def test_fetch_active_books_uses_custom_pagination(mock_mongo, test_app):
+    """
+    GIVEN custom offset and limit arguments
+    WHEN fetch_active_books is called
+    THEN it should query the database using those specific values.
+    """
+    # ARRANGE
+    mock_mongo.db.books.find.return_value.skip.return_value.limit.return_value = []
+
+    with test_app.app_context():
+        # ACT: Call the function with custom arguments
+        fetch_active_books(offset=10, limit=5)
+
+    # ASSERT
+    # Check that the database methods were called with the custom values
+    expected_filter = {"state": {"$ne": "deleted"}}
+    mock_mongo.db.books.find.assert_called_once_with(expected_filter)
+    mock_mongo.db.books.find.return_value.skip.assert_called_once_with(10)
+    mock_mongo.db.books.find.return_value.skip.return_value.limit.assert_called_once_with(5)

--- a/tests/test_book_service.py
+++ b/tests/test_book_service.py
@@ -1,0 +1,25 @@
+"""Unit tests for the book service layer."""
+
+from unittest.mock import patch
+
+from app.services.book_service import count_active_books
+
+
+def test_count_active_books_returns_correct_count(test_app):
+    """
+    GIVEN a mocked database layer
+    WHEN count_active_books()
+    THEN it should call the underlying database method wiht the correct query
+    AND return the mocked value
+    """
+    # Arrange: set patch target
+    with patch("app.services.book_service.mongo") as mock_mongo:
+        mock_mongo.db.books.count_documents.return_value = 5
+
+        with test_app.app_context():
+            # Act
+            result = count_active_books()
+
+        assert result == 5
+        expected_query = {"state": {"$ne": "deleted"}}
+        mock_mongo.db.books.count_documents.assert_called_once_with(expected_query)

--- a/tests/test_pagination.py
+++ b/tests/test_pagination.py
@@ -1,0 +1,24 @@
+"""
+Tests for the GET /books endpoint, specifically focusing on pagination logic.
+"""
+
+import pytest
+
+@pytest.mark.parametrize("query_params, expected_error_msg", [
+    ("?limit=-5", "cannot be negative"),
+    ("?offset=-1", "cannot be negative"),
+    ("?limit=abc", "must be integers"),
+    ("?offset=abc", "must be integers"),
+])
+def test_get_books_with_invalid_params(client, query_params, expected_error_msg):
+    """
+    GIVEN any client
+    WHEN a GET request is made to /books with invalid pagination parameters
+    THEN it should return a 400 Bad Request wiht a relevant error message.
+    """
+    response = client.get(f"/books{query_params}")
+    json_data = response.get_json()
+
+    assert response.status_code == 400
+    assert "error" in json_data
+    assert expected_error_msg in json_data["error"]

--- a/tests/test_pagination.py
+++ b/tests/test_pagination.py
@@ -4,12 +4,16 @@ Tests for the GET /books endpoint, specifically focusing on pagination logic.
 
 import pytest
 
-@pytest.mark.parametrize("query_params, expected_error_msg", [
-    ("?limit=-5", "cannot be negative"),
-    ("?offset=-1", "cannot be negative"),
-    ("?limit=abc", "must be integers"),
-    ("?offset=abc", "must be integers"),
-])
+
+@pytest.mark.parametrize(
+    "query_params, expected_error_msg",
+    [
+        ("?limit=-5", "cannot be negative"),
+        ("?offset=-1", "cannot be negative"),
+        ("?limit=abc", "must be integers"),
+        ("?offset=abc", "must be integers"),
+    ],
+)
 def test_get_books_with_invalid_params(client, query_params, expected_error_msg):
     """
     GIVEN any client


### PR DESCRIPTION
## Description

Trello ticket: https://trello.com/c/mSJXk7rG
This PR implements offset/limit based pagination for the GET /books endpoint and updates the OpenAPI spec accordingly. 
- It also adds server-side validation for the pagination query parameters, 
- Improves the helper that counts active books (with connection-failure handling),
- Adapts fetch_active_books() to support pagination and PyMongo behavior, and 
- Adds comprehensive tests and fixtures to cover the default and custom pagination behavior.


_Please include a summary of the change and which issue is fixed. Include relevant motivation and context. Place 'x' between the square brackets to tick an option. (This context should also be present in your commit messages where appropriate.)_


## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## How Has This Been Tested?

Unit tests, integration tests, CURL request, editor.swagger.io

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] **My individual commit messages are descriptive and follow our [commit guidelines](https://martijnhols.nl/blog/how-to-write-a-good-git-commit-message/)**
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

