### PR TITLE
Add reservation pagination with offset and limit

### DIFF
--- a/app/routes/reservation_routes.py
+++ b/app/routes/reservation_routes.py
@@ -1,3 +1,4 @@
+# pylint: disable=duplicate-code
 """Routes for /books/<id>/reservations endpoint"""
 
 import datetime

--- a/app/routes/reservation_routes.py
+++ b/app/routes/reservation_routes.py
@@ -5,7 +5,7 @@ import logging
 
 from bson import ObjectId
 from bson.errors import InvalidId
-from flask import Blueprint, g, jsonify, url_for, request
+from flask import Blueprint, g, jsonify, request, url_for
 
 from app.extensions import mongo
 from app.utils.decorators import require_admin, require_jwt
@@ -103,9 +103,7 @@ def get_reservations_for_book_id(book_id_str):
     if offset < 0 or limit < 0:
         return (
             jsonify(
-                {
-                    "error": "Query parameters 'limit' and 'offset' cannot be negative."
-                }
+                {"error": "Query parameters 'limit' and 'offset' cannot be negative."}
             ),
             400,
         )

--- a/app/services/reservation_services.py
+++ b/app/services/reservation_services.py
@@ -1,0 +1,10 @@
+"""..."""
+
+from bson import ObjectId
+
+from app.extensions import mongo
+
+
+def count_reservations_for_book(book_id: ObjectId) -> int:
+    """Counts the total number of reservations for a given book ID"""
+    return mongo.db.reservations.count_documents({"book_id": book_id})

--- a/app/services/reservation_services.py
+++ b/app/services/reservation_services.py
@@ -1,4 +1,4 @@
-"""..."""
+"""Service layer functions for reservation data operations"""
 
 from bson import ObjectId
 

--- a/app/services/reservation_services.py
+++ b/app/services/reservation_services.py
@@ -8,3 +8,35 @@ from app.extensions import mongo
 def count_reservations_for_book(book_id: ObjectId) -> int:
     """Counts the total number of reservations for a given book ID"""
     return mongo.db.reservations.count_documents({"book_id": book_id})
+
+
+def fetch_reservations_for_book(
+    book_id: ObjectId, offset: int = 0, limit: int = 20
+) -> list:
+    """
+    Fetches a paginated list of reservations for a book using an efficient
+    aggregation pipeline to include user details.
+    """
+    pipeline = [
+        # Stage 1: Find all reservations that match the book_id
+        {"$match": {"book_id": book_id}},
+        # Stage 2: Join ($lookup = JOIN in SQL) with the user collections
+        {
+            "$lookup": {
+                "from": "users",  # The collection to join with
+                "localField": "user_id",  # The field from the reservations collection
+                "foreignField": "_id",  # The field from the users collection
+                "as": "userDetails",  # The name of the new array field to add
+            }
+        },
+        # Stage 3: $lookup returns an array. We only expect one user per reservation,
+        # so $unwind flattens the array.
+        {"$unwind": "$userDetails"},
+        # Stage 4 & 5: Apply pagination to the result of the aggregation
+        {"$skip": offset},
+        {"$limit": limit},
+    ]
+    # use the aggregate() MongoDB collection method with 'pipeline'
+    # tells MongoDb "run this aggregation pipeline against the collection"
+    cursor = mongo.db.reservations.aggregate(pipeline)
+    return list(cursor)

--- a/openapi.yml
+++ b/openapi.yml
@@ -242,11 +242,15 @@ components:
           example: "2023-10-27T10:00:00Z"
 
 
-    # Schema for the GET /reservations response body (a list)
-    ReservationsOutput:
+    # Schema for a paginated list of reservations
+    ReservationsListResponse:
       type: object
       properties:
-        reservations:
+        total_count:
+          type: integer
+          description: Total number of reservations for this book.
+          example: 5
+        items:
           type: array
           items:
             $ref: '#/components/schemas/ReservationOutput'
@@ -629,15 +633,41 @@ paths:
       tags:
         - Reservations
       summary: Get all reservations for a book
-      description: Fetches a list of all active reservations for the book identified by {book_id}.
+      description: Fetches a paginated list of all active reservations for the book identified by {book_id}.
       operationId: get_book_reservations
+      parameters:
+        - name: offset
+          in: query
+          description: The number of reservations to skip before starting to collect the result set.
+          required: false
+          schema:
+            type: integer
+            format: int32
+            default: 0
+            minimum: 0
+        - name: limit
+          in: query
+          description: The maximum number of reservations to return.
+          required: false
+          schema:
+            type: integer
+            format: int32
+            default: 20
+            minimum: 1
+            maximum: 100
       responses:
         '200': 
           description: Successfully retrieved the list of reservations.
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ReservationsOutput'
+                $ref: '#/components/schemas/ReservationsListResponse'
+        '400':
+          description: Invalid query parameters provided (e.g., negative offset).
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SimpleError'
         '404':
           $ref: '#/components/responses/NotFound'
         '500':

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -152,7 +152,6 @@ def seeded_books_in_db(test_app):  # pylint: disable=redefined-outer-name
     Ensures the books collection is clean and then seeds it with 50 books
     for pagination testing.
     """
-    # _ = mongo_setup
 
     with test_app.app_context():
         collection = get_book_collection()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -147,15 +147,16 @@ def mongo_setup(test_app):  # pylint: disable=redefined-outer-name
 
 
 @pytest.fixture
-def seeded_books_in_db(test_app, mongo_setup): # pylint: disable=redefined-outer-name
+def seeded_books_in_db(test_app): # pylint: disable=redefined-outer-name
     """
     Ensures the books collection is clean and then seeds it with 50 books
-    for pagination testting.
+    for pagination testing.
     """
-    _ = mongo_setup
+    #_ = mongo_setup
 
     with test_app.app_context():
         collection = get_book_collection()
+        collection.delete_many({}) # clear old data before seeding
         books_to_insert = [
             {
                 "_id": f"book_{i}",
@@ -168,7 +169,7 @@ def seeded_books_in_db(test_app, mongo_setup): # pylint: disable=redefined-outer
             collection.insert_many(books_to_insert)
         print("books_to_insert: ", books_to_insert)
 
-    return books_to_insert()
+    return books_to_insert
 
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -147,22 +147,18 @@ def mongo_setup(test_app):  # pylint: disable=redefined-outer-name
 
 
 @pytest.fixture
-def seeded_books_in_db(test_app): # pylint: disable=redefined-outer-name
+def seeded_books_in_db(test_app):  # pylint: disable=redefined-outer-name
     """
     Ensures the books collection is clean and then seeds it with 50 books
     for pagination testing.
     """
-    #_ = mongo_setup
+    # _ = mongo_setup
 
     with test_app.app_context():
         collection = get_book_collection()
-        collection.delete_many({}) # clear old data before seeding
+        collection.delete_many({})  # clear old data before seeding
         books_to_insert = [
-            {
-                "_id": f"book_{i}",
-                "title": f"Test Book {i}",
-                "state": "active"
-            }
+            {"_id": f"book_{i}", "title": f"Test Book {i}", "state": "active"}
             for i in range(50)
         ]
         if books_to_insert:
@@ -170,8 +166,6 @@ def seeded_books_in_db(test_app): # pylint: disable=redefined-outer-name
         print("books_to_insert: ", books_to_insert)
 
     return books_to_insert
-
-
 
 
 TEST_USER_ID = "6154b3a3e4a5b6c7d8e9f0a1"

--- a/tests/test_pagination.py
+++ b/tests/test_pagination.py
@@ -4,12 +4,16 @@ Tests for the GET /books endpoint, specifically focusing on pagination logic.
 
 import pytest
 
-@pytest.mark.parametrize("query_params, expected_error_msg", [
-    ("?limit=-5", "cannot be negative"),
-    ("?offset=-1", "cannot be negative"),
-    ("?limit=abc", "must be integers"),
-    ("?offset=abc", "must be integers"),
-])
+
+@pytest.mark.parametrize(
+    "query_params, expected_error_msg",
+    [
+        ("?limit=-5", "cannot be negative"),
+        ("?offset=-1", "cannot be negative"),
+        ("?limit=abc", "must be integers"),
+        ("?offset=abc", "must be integers"),
+    ],
+)
 def test_get_books_with_invalid_params(client, query_params, expected_error_msg):
     """
     GIVEN any client

--- a/tests/test_reservation_services.py
+++ b/tests/test_reservation_services.py
@@ -7,7 +7,7 @@ from bson import ObjectId
 from app.services.reservation_services import count_reservations_for_book
 
 
-@patch("app.services.reservation_service.mongo")
+@patch("app.services.reservation_services.mongo")
 def test_count_reservations_for_book(mock_mongo, test_app):
     """
     WHEN count_reservations_for_book is called with a book_id

--- a/tests/test_reservation_services.py
+++ b/tests/test_reservation_services.py
@@ -1,0 +1,29 @@
+"""..."""
+
+from unittest.mock import patch
+
+from bson import ObjectId
+
+from app.services.reservation_services import count_reservations_for_book
+
+
+@patch("app.services.reservation_service.mongo")
+def test_count_reservations_for_book(mock_mongo, test_app):
+    """
+    WHEN count_reservations_for_book is called with a book_id
+    THEN it should call count_documents on the reservations collection
+    WITH the correct filter
+    """
+    # Arrange
+    book_id_obj = ObjectId()
+    mock_mongo.db.reservations.count_documents.return_value = 5
+
+    with test_app.app_context():
+        # ACT
+        result = count_reservations_for_book(book_id_obj)
+
+    # Assert
+    assert result == 5
+    mock_mongo.db.reservations.count_documents.assert_called_once_with(
+        {"book_id": book_id_obj}
+    )

--- a/tests/test_reservation_services.py
+++ b/tests/test_reservation_services.py
@@ -1,5 +1,5 @@
 # pylint: disable=line-too-long
-"""..."""
+"""Tests for reservation service layer functions."""
 
 from unittest.mock import patch
 
@@ -32,10 +32,10 @@ def test_count_reservations_for_book(mock_mongo, test_app):
 
 
 # Plan: Write unit tests that mock the .aggregate method
-# the tests will not check the data returned, instead will inspect the piepline arugment that is passed to aggregate to enusre it's constructed propertly based in the book_od, offset, and limit provided
+# the tests will not check the data returned, instead will inspect the pipeline argument that is passed to aggregate to ensure it's constructed properly based on the book_id, offset, and limit provided
 # KEY PRINCIPLE- we are not testing if MongoDB can perform an aggregation- we trust it can.
 # we are testing that our function correctly builds the list of instructions (the pipeline) that we send to MongoDB.
-# THEREFORE: our test's most important job is to "capture" the pipeline variable that the fucntion creates
+# THEREFORE: our test's most important job is to "capture" the pipeline variable that the function creates
 # and assert that its contents are exactly what we expect.
 
 

--- a/tests/test_reservations.py
+++ b/tests/test_reservations.py
@@ -357,24 +357,31 @@ def test_get_reservations_skips_reservation_with_nonexistent_user(
     assert returned_reservation["state"] == "active"
 
 
-@pytest.mark.parametrize("query_params, expected_error_msg", [
-    ("?limit=-5", "cannot be negative"),
-    ("?offset=-1", "cannot be negative"),
-    ("?limit=abc", "must be integers"),
-    ("?offset=xyz", "must be integers"),
-])
-def test_get_reservations_with_invalid_params(client, seeded_books_in_db, admin_token, query_params, expected_error_msg): # pylint: disable=line-too-long
+@pytest.mark.parametrize(
+    "query_params, expected_error_msg",
+    [
+        ("?limit=-5", "cannot be negative"),
+        ("?offset=-1", "cannot be negative"),
+        ("?limit=abc", "must be integers"),
+        ("?offset=xyz", "must be integers"),
+    ],
+)
+def test_get_reservations_with_invalid_params(
+    client, seeded_books_in_db, admin_token, query_params, expected_error_msg
+):  # pylint: disable=line-too-long
     """
     GIVEN a valid book ID and admin credentials
     WHEN a GET request is made to the reservations endpoint with invalid pagination parameters
     THEN it should return a 400 Bad Request with a relevant error message.
     """
     # ARRANGE: Get a valid book ID from our seeded data
-    book_id_str = seeded_books_in_db[0]['_id']
+    book_id_str = seeded_books_in_db[0]["_id"]
     auth_headers = {"Authorization": f"Bearer {admin_token}"}
 
     # ACT
-    response = client.get(f"/books/{book_id_str}/reservations{query_params}", headers=auth_headers)
+    response = client.get(
+        f"/books/{book_id_str}/reservations{query_params}", headers=auth_headers
+    )
     json_data = response.get_json()
 
     # ASSERT

--- a/tests/test_reservations.py
+++ b/tests/test_reservations.py
@@ -355,3 +355,29 @@ def test_get_reservations_skips_reservation_with_nonexistent_user(
     returned_reservation = data["items"][0]
     # We can't check the user ID directly in the new format, but we can check the state
     assert returned_reservation["state"] == "active"
+
+
+@pytest.mark.parametrize("query_params, expected_error_msg", [
+    ("?limit=-5", "cannot be negative"),
+    ("?offset=-1", "cannot be negative"),
+    ("?limit=abc", "must be integers"),
+    ("?offset=xyz", "must be integers"),
+])
+def test_get_reservations_with_invalid_params(client, seeded_books_in_db, admin_token, query_params, expected_error_msg): # pylint: disable=line-too-long
+    """
+    GIVEN a valid book ID and admin credentials
+    WHEN a GET request is made to the reservations endpoint with invalid pagination parameters
+    THEN it should return a 400 Bad Request with a relevant error message.
+    """
+    # ARRANGE: Get a valid book ID from our seeded data
+    book_id_str = seeded_books_in_db[0]['_id']
+    auth_headers = {"Authorization": f"Bearer {admin_token}"}
+
+    # ACT
+    response = client.get(f"/books/{book_id_str}/reservations{query_params}", headers=auth_headers)
+    json_data = response.get_json()
+
+    # ASSERT
+    assert response.status_code == 400
+    assert "error" in json_data
+    assert expected_error_msg in json_data["error"]

--- a/tests/test_reservations.py
+++ b/tests/test_reservations.py
@@ -312,9 +312,10 @@ def test_get_reservations_skips_reservation_with_nonexistent_user(
     mock_url_for, client, admin_token, seeded_user_in_db, test_app
 ):
     """
-    GIVEN a book with two reservations, one for a valid user and one for a user that does not exist
+    GIVEN a book with an orphan reservation (non-existent user)
     WHEN the GET /books/{id}/reservations endpoint is hit
-    THEN it should return 200 OK and a list containing ONLY the valid reservation.
+    THEN it should return 200 OK, a total_count reflecting all reservations,
+    AND an items list containing ONLY the valid reservation.
     """
     # --- ARRANGE ---
     mock_url_for.return_value = "http://localhost/mock/url"
@@ -348,7 +349,7 @@ def test_get_reservations_skips_reservation_with_nonexistent_user(
     data = response.get_json()
 
     # The endpoint should successfully process the request and return only the valid data
-    assert data["total_count"] == 1
+    assert data["total_count"] == 2
     assert len(data["items"]) == 1
 
     # The only item returned should be the one linked to the valid user


### PR DESCRIPTION
## Description

Trello ticket: https://trello.com/c/mSJXk7rG
- This PR implements offset/limit based pagination for the GET /books/{id}/reservation endpoint and updates the OpenAPI spec accordingly.
- As part of this implementation, the data fetching logic has been significantly refactored to use a MongoDB aggregation pipeline. This resolves a critical N+1 query performance issue, making the endpoint far more efficient and scalable for books with a large number of reservations.


## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update
- [x] Code refactor (improving code quality without changing functionality)
- [x] Performance improvement


## How Has This Been Tested?

The feature was developed using a TDD approach with automated tests and manual curl verification. Swagger spec was verified with swagger.editor.io

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] **My individual commit messages are descriptive and follow our [commit guidelines](https://martijnhols.nl/blog/how-to-write-a-good-git-commit-message/)**
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
