### PR TITLE
Extend GET pagination endpoints with max default offset

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,6 +1,7 @@
 [run]
 omit =
     */conftest.py
+    app/config.py
 
 [report]
 # Exclude lines from coverage report

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,5 +39,6 @@ jobs:
           MONGO_CONNECTION: ${{ secrets.MONGO_CONNECTION }}
           PROJECT_DATABASE: ${{ secrets.PROJECT_DATABASE }}
           PROJECT_COLLECTION: ${{ secrets.PROJECT_COLLECTION}}
+          MAX_OFFSET: 2000
         run: |
           ./run_tests.sh

--- a/app/config.py
+++ b/app/config.py
@@ -37,4 +37,4 @@ class Config:
     try:
         MAX_OFFSET = int(os.environ.get("MAX_OFFSET", "5000"))
     except (ValueError, TypeError):
-        MAX_OFFSET = 5000
+        MAX_OFFSET = 2000

--- a/app/config.py
+++ b/app/config.py
@@ -34,3 +34,7 @@ class Config:
     MONGO_URI = os.environ.get("MONGO_CONNECTION")
     DB_NAME = os.environ.get("PROJECT_DATABASE")
     COLLECTION_NAME = os.environ.get("PROJECT_COLLECTION")
+    try:
+        MAX_OFFSET = int(os.environ.get("MAX_OFFSET", "5000"))
+    except (ValueError, TypeError):
+        MAX_OFFSET = 5000

--- a/app/routes/legacy_routes.py
+++ b/app/routes/legacy_routes.py
@@ -134,11 +134,14 @@ def register_legacy_routes(app):  # pylint: disable=too-many-statements
         max_offset = current_app.config["MAX_OFFSET"]
         print(max_offset, offset)
         if offset < 0 or offset > max_offset:
-            return jsonify(
-                {
-                    "error": f"Offset has to be a positive number no greater then {max_offset}."
-                }
-            ), 400
+            return (
+                jsonify(
+                    {
+                        "error": f"Offset has to be a positive number no greater then {max_offset}."
+                    }
+                ),
+                400,
+            )
 
         # --- 2. Call the Service Layer to Fetch Data ---
 

--- a/app/routes/legacy_routes.py
+++ b/app/routes/legacy_routes.py
@@ -1,7 +1,7 @@
 """Flask application module for managing a collection of books."""
 
 from bson.objectid import InvalidId, ObjectId
-from flask import jsonify, request
+from flask import current_app, jsonify, request
 from pymongo.errors import ConnectionFailure
 from werkzeug.exceptions import HTTPException, NotFound
 
@@ -117,7 +117,7 @@ def register_legacy_routes(app):  # pylint: disable=too-many-statements
                     {"error": "Query parameters 'limit' and 'offset' must be integers."}
                 ),
                 400,
-            )  # pylint: disable=line-too-long
+            )
 
         if offset < 0 or limit < 0:
             return (
@@ -127,7 +127,18 @@ def register_legacy_routes(app):  # pylint: disable=too-many-statements
                     }
                 ),
                 400,
-            )  # pylint: disable=line-too-long
+            )
+
+        # Validate MAX_OFFSET
+        # get the MAX_OFFSET value from env and check
+        max_offset = current_app.config["MAX_OFFSET"]
+        print(max_offset, offset)
+        if offset < 0 or offset > max_offset:
+            return jsonify(
+                {
+                    "error": f"Offset has to be a positive number no greater then {max_offset}."
+                }
+            ), 400
 
         # --- 2. Call the Service Layer to Fetch Data ---
 

--- a/app/routes/legacy_routes.py
+++ b/app/routes/legacy_routes.py
@@ -119,7 +119,7 @@ def register_legacy_routes(app):  # pylint: disable=too-many-statements
                 400,
             )
 
-        if offset < 0 or limit < 0:
+        if limit < 0:
             return (
                 jsonify(
                     {

--- a/app/routes/legacy_routes.py
+++ b/app/routes/legacy_routes.py
@@ -132,12 +132,12 @@ def register_legacy_routes(app):  # pylint: disable=too-many-statements
         # Validate MAX_OFFSET
         # get the MAX_OFFSET value from env and check
         max_offset = current_app.config["MAX_OFFSET"]
-        print(max_offset, offset)
+
         if offset < 0 or offset > max_offset:
             return (
                 jsonify(
                     {
-                        "error": f"Offset has to be a positive number no greater then {max_offset}."
+                        "error": f"Offset has to be a positive number no greater than {max_offset}."
                     }
                 ),
                 400,

--- a/app/routes/reservation_routes.py
+++ b/app/routes/reservation_routes.py
@@ -5,7 +5,7 @@ import datetime
 
 from bson import ObjectId
 from bson.errors import InvalidId
-from flask import Blueprint, g, jsonify, request, url_for
+from flask import Blueprint, g, jsonify, request, url_for, current_app
 
 from app.extensions import mongo
 from app.services.reservation_services import (count_reservations_for_book,
@@ -102,13 +102,23 @@ def get_reservations_for_book_id(book_id_str):
             400,
         )  # pylint: disable=line-too-long
 
-    if offset < 0 or limit < 0:
+    if limit < 0:
         return (
             jsonify(
                 {"error": "Query parameters 'limit' and 'offset' cannot be negative."}
             ),
             400,
         )
+    # Validate MAX_OFFSET
+    # get the MAX_OFFSET value from env and check
+    max_offset = current_app.config["MAX_OFFSET"]
+    print(max_offset, offset)
+    if offset < 0 or offset > max_offset:
+        return jsonify(
+            {
+                "error": f"Offset has to be a positive number no greater then {max_offset}."
+            }
+        ), 400
 
     # Validate the book_id format
     try:

--- a/app/routes/reservation_routes.py
+++ b/app/routes/reservation_routes.py
@@ -5,7 +5,7 @@ import datetime
 
 from bson import ObjectId
 from bson.errors import InvalidId
-from flask import Blueprint, g, jsonify, request, url_for, current_app
+from flask import Blueprint, current_app, g, jsonify, request, url_for
 
 from app.extensions import mongo
 from app.services.reservation_services import (count_reservations_for_book,
@@ -114,11 +114,14 @@ def get_reservations_for_book_id(book_id_str):
     max_offset = current_app.config["MAX_OFFSET"]
     print(max_offset, offset)
     if offset < 0 or offset > max_offset:
-        return jsonify(
-            {
-                "error": f"Offset has to be a positive number no greater then {max_offset}."
-            }
-        ), 400
+        return (
+            jsonify(
+                {
+                    "error": f"Offset has to be a positive number no greater then {max_offset}."
+                }
+            ),
+            400,
+        )
 
     # Validate the book_id format
     try:

--- a/app/routes/reservation_routes.py
+++ b/app/routes/reservation_routes.py
@@ -112,12 +112,12 @@ def get_reservations_for_book_id(book_id_str):
     # Validate MAX_OFFSET
     # get the MAX_OFFSET value from env and check
     max_offset = current_app.config["MAX_OFFSET"]
-    print(max_offset, offset)
+
     if offset < 0 or offset > max_offset:
         return (
             jsonify(
                 {
-                    "error": f"Offset has to be a positive number no greater then {max_offset}."
+                    "error": f"Offset has to be a positive number no greater than {max_offset}."
                 }
             ),
             400,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -162,7 +162,6 @@ def seeded_books_in_db(test_app):  # pylint: disable=redefined-outer-name
         ]
         if books_to_insert:
             collection.insert_many(books_to_insert)
-        print("books_to_insert: ", books_to_insert)
 
     return books_to_insert
 

--- a/tests/test_pagination.py
+++ b/tests/test_pagination.py
@@ -1,3 +1,4 @@
+# pylint: disable=duplicate-code
 """
 Tests for the GET /books endpoint, specifically focusing on pagination logic.
 """

--- a/tests/test_pagination.py
+++ b/tests/test_pagination.py
@@ -4,7 +4,6 @@ Tests for the GET /books endpoint, specifically focusing on pagination logic.
 
 import pytest
 
-
 @pytest.mark.parametrize(
     "query_params, expected_error_msg",
     [
@@ -26,3 +25,26 @@ def test_get_books_with_invalid_params(client, query_params, expected_error_msg)
     assert response.status_code == 400
     assert "error" in json_data
     assert expected_error_msg in json_data["error"]
+
+invalid_offset_values = [-1, 2001]
+
+@pytest.mark.parametrize("invalid_offset", invalid_offset_values)
+def test_get_books_fails_for_out_of_range_offset(client, invalid_offset):
+    """
+    GIVEN an offset that is either negative or exceeds the configured max
+    WHEN a GET request is made to /books with that offset
+    THEN it should return a 400 Bad Request with the correct error message.
+    """
+    # Arrange
+    # Get the max_offset from the app's config to build the expected message.
+    max_offset = client.application.config['MAX_OFFSET']
+    expected_error_msg = f"Offset has to be a positive number no greater then {max_offset}."
+
+    # Act
+    response = client.get(f"/books?offset={invalid_offset}")
+    json_data = response.get_json()
+
+    # Assert
+    assert response.status_code == 400
+    assert "error" in json_data
+    assert json_data["error"] in expected_error_msg

--- a/tests/test_pagination.py
+++ b/tests/test_pagination.py
@@ -42,7 +42,7 @@ def test_get_books_fails_for_out_of_range_offset(client, invalid_offset):
     # Get the max_offset from the app's config to build the expected message.
     max_offset = client.application.config["MAX_OFFSET"]
     expected_error_msg = (
-        f"Offset has to be a positive number no greater then {max_offset}."
+        f"Offset has to be a positive number no greater than {max_offset}."
     )
 
     # Act

--- a/tests/test_pagination.py
+++ b/tests/test_pagination.py
@@ -8,7 +8,6 @@ import pytest
     "query_params, expected_error_msg",
     [
         ("?limit=-5", "cannot be negative"),
-        ("?offset=-1", "cannot be negative"),
         ("?limit=abc", "must be integers"),
         ("?offset=abc", "must be integers"),
     ],

--- a/tests/test_pagination.py
+++ b/tests/test_pagination.py
@@ -4,6 +4,7 @@ Tests for the GET /books endpoint, specifically focusing on pagination logic.
 
 import pytest
 
+
 @pytest.mark.parametrize(
     "query_params, expected_error_msg",
     [
@@ -25,7 +26,9 @@ def test_get_books_with_invalid_params(client, query_params, expected_error_msg)
     assert "error" in json_data
     assert expected_error_msg in json_data["error"]
 
+
 invalid_offset_values = [-1, 2001]
+
 
 @pytest.mark.parametrize("invalid_offset", invalid_offset_values)
 def test_get_books_fails_for_out_of_range_offset(client, invalid_offset):
@@ -36,8 +39,10 @@ def test_get_books_fails_for_out_of_range_offset(client, invalid_offset):
     """
     # Arrange
     # Get the max_offset from the app's config to build the expected message.
-    max_offset = client.application.config['MAX_OFFSET']
-    expected_error_msg = f"Offset has to be a positive number no greater then {max_offset}."
+    max_offset = client.application.config["MAX_OFFSET"]
+    expected_error_msg = (
+        f"Offset has to be a positive number no greater then {max_offset}."
+    )
 
     # Act
     response = client.get(f"/books?offset={invalid_offset}")

--- a/tests/test_reservations.py
+++ b/tests/test_reservations.py
@@ -389,9 +389,14 @@ def test_get_reservations_with_invalid_params(
     assert "error" in json_data
     assert expected_error_msg in json_data["error"]
 
+
 invalid_offset_values = [-1, 2001]
+
+
 @pytest.mark.parametrize("invalid_offset", invalid_offset_values)
-def test_get_reservations_fails_for_out_of_range_offset(client, seeded_books_in_db, admin_token, invalid_offset): # pylint: disable=line-too-long
+def test_get_reservations_fails_for_out_of_range_offset(
+    client, seeded_books_in_db, admin_token, invalid_offset
+):  # pylint: disable=line-too-long
     """
     GIVEN an offset that is either negative or exceeds the configured max
     WHEN a GET request is made to /books/{id}/endpoint with that offset
@@ -402,13 +407,15 @@ def test_get_reservations_fails_for_out_of_range_offset(client, seeded_books_in_
     auth_headers = {"Authorization": f"Bearer {admin_token}"}
     # Arrange
     # Get the max_offset from the app's config to build the expected message.
-    max_offset = client.application.config['MAX_OFFSET']
-    expected_error_msg = f"Offset has to be a positive number no greater then {max_offset}."
+    max_offset = client.application.config["MAX_OFFSET"]
+    expected_error_msg = (
+        f"Offset has to be a positive number no greater then {max_offset}."
+    )
 
     # Act
     response = client.get(
         f"/books/{book_id_str}/reservations?offset={invalid_offset}",
-        headers=auth_headers
+        headers=auth_headers,
     )
     json_data = response.get_json()
 

--- a/tests/test_reservations.py
+++ b/tests/test_reservations.py
@@ -389,3 +389,31 @@ def test_get_reservations_with_invalid_params(
     assert response.status_code == 400
     assert "error" in json_data
     assert expected_error_msg in json_data["error"]
+
+invalid_offset_values = [-1, 2001]
+@pytest.mark.parametrize("invalid_offset", invalid_offset_values)
+def test_get_reservations_fails_for_out_of_range_offset(client, seeded_books_in_db, admin_token, invalid_offset): # pylint: disable=line-too-long
+    """
+    GIVEN an offset that is either negative or exceeds the configured max
+    WHEN a GET request is made to /books/{id}/endpoint with that offset
+    THEN it should return a 400 Bad Request with the correct error message.
+    """
+    # ARRANGE: Get a valid book ID from our seeded data
+    book_id_str = seeded_books_in_db[0]["_id"]
+    auth_headers = {"Authorization": f"Bearer {admin_token}"}
+    # Arrange
+    # Get the max_offset from the app's config to build the expected message.
+    max_offset = client.application.config['MAX_OFFSET']
+    expected_error_msg = f"Offset has to be a positive number no greater then {max_offset}."
+
+    # Act
+    response = client.get(
+        f"/books/{book_id_str}/reservations?offset={invalid_offset}",
+        headers=auth_headers
+    )
+    json_data = response.get_json()
+
+    # Assert
+    assert response.status_code == 400
+    assert "error" in json_data
+    assert json_data["error"] in expected_error_msg

--- a/tests/test_reservations.py
+++ b/tests/test_reservations.py
@@ -409,7 +409,7 @@ def test_get_reservations_fails_for_out_of_range_offset(
     # Get the max_offset from the app's config to build the expected message.
     max_offset = client.application.config["MAX_OFFSET"]
     expected_error_msg = (
-        f"Offset has to be a positive number no greater then {max_offset}."
+        f"Offset has to be a positive number no greater than {max_offset}."
     )
 
     # Act

--- a/tests/test_reservations.py
+++ b/tests/test_reservations.py
@@ -362,7 +362,6 @@ def test_get_reservations_skips_reservation_with_nonexistent_user(
     "query_params, expected_error_msg",
     [
         ("?limit=-5", "cannot be negative"),
-        ("?offset=-1", "cannot be negative"),
         ("?limit=abc", "must be integers"),
         ("?offset=xyz", "must be integers"),
     ],


### PR DESCRIPTION
## Description

Trello card: https://trello.com/c/dRDnYYYO
This PR introduces a configurable maximum offset value for pagination across reservation endpoints.
- Adds a MAX_OFFSET environment variable with a fallback default of 2000.
- Ensures offsets cannot exceed this maximum; otherwise, a validation error is raised.
- Default offset remains 0 for normal pagination use.
- Cleans up redundant offset validation logic and tests.

**Fixes # (issue number if applicable)**

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)


## How Has This Been Tested?
- Added unit tests for invalid offset values (negative, above max).
- Updated reservation service and controller tests to validate new logic.
- Verified default behavior when no MAX_OFFSET is provided.
- Ran full test suite – all tests passing.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] **My individual commit messages are descriptive and follow our [commit guidelines](https://martijnhols.nl/blog/how-to-write-a-good-git-commit-message/)**
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

