### PR TITLE
Extend GET pagination to include a maximum default limit

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,5 +40,6 @@ jobs:
           PROJECT_DATABASE: ${{ secrets.PROJECT_DATABASE }}
           PROJECT_COLLECTION: ${{ secrets.PROJECT_COLLECTION}}
           MAX_OFFSET: 2000
+          MAX_LIMIT: 1000
         run: |
           ./run_tests.sh

--- a/app/config.py
+++ b/app/config.py
@@ -35,6 +35,10 @@ class Config:
     DB_NAME = os.environ.get("PROJECT_DATABASE")
     COLLECTION_NAME = os.environ.get("PROJECT_COLLECTION")
     try:
-        MAX_OFFSET = int(os.environ.get("MAX_OFFSET", "5000"))
+        MAX_OFFSET = int(os.environ.get("MAX_OFFSET", "2000"))
     except (ValueError, TypeError):
         MAX_OFFSET = 2000
+    try:
+        MAX_LIMIT = int(os.environ.get("MAX_LIMIT", "1000"))
+    except (ValueError, TypeError):
+        MAX_LIMIT = 1000

--- a/app/routes/legacy_routes.py
+++ b/app/routes/legacy_routes.py
@@ -119,15 +119,15 @@ def register_legacy_routes(app):  # pylint: disable=too-many-statements
                 400,
             )
 
-        if limit < 0:
-            return (
-                jsonify(
-                    {
-                        "error": "Query parameters 'limit' and 'offset' cannot be negative."
-                    }
-                ),
-                400,
-            )
+        # if limit < 0:
+        #     return (
+        #         jsonify(
+        #             {
+        #                 "error": "Query parameters 'limit' and 'offset' cannot be negative."
+        #             }
+        #         ),
+        #         400,
+        #     )
 
         # Validate MAX_OFFSET
         # get the MAX_OFFSET value from env and check
@@ -143,6 +143,18 @@ def register_legacy_routes(app):  # pylint: disable=too-many-statements
                 400,
             )
 
+        # Validate MAX_LIMIT
+        max_limit = current_app.config["MAX_LIMIT"]
+
+        if limit < 0 or limit > max_limit:
+            return (
+                jsonify(
+                    {
+                        "error": f"Limit has to be a positive number no greater than {max_limit}."
+                    }
+                ),
+                400,
+            )
         # --- 2. Call the Service Layer to Fetch Data ---
 
         try:

--- a/app/routes/legacy_routes.py
+++ b/app/routes/legacy_routes.py
@@ -119,16 +119,6 @@ def register_legacy_routes(app):  # pylint: disable=too-many-statements
                 400,
             )
 
-        # if limit < 0:
-        #     return (
-        #         jsonify(
-        #             {
-        #                 "error": "Query parameters 'limit' and 'offset' cannot be negative."
-        #             }
-        #         ),
-        #         400,
-        #     )
-
         # Validate MAX_OFFSET
         # get the MAX_OFFSET value from env and check
         max_offset = current_app.config["MAX_OFFSET"]

--- a/app/routes/reservation_routes.py
+++ b/app/routes/reservation_routes.py
@@ -102,13 +102,13 @@ def get_reservations_for_book_id(book_id_str):
             400,
         )  # pylint: disable=line-too-long
 
-    if limit < 0:
-        return (
-            jsonify(
-                {"error": "Query parameters 'limit' and 'offset' cannot be negative."}
-            ),
-            400,
-        )
+    # if limit < 0:
+    #     return (
+    #         jsonify(
+    #             {"error": "Query parameters 'limit' and 'offset' cannot be negative."}
+    #         ),
+    #         400,
+    #     )
     # Validate MAX_OFFSET
     # get the MAX_OFFSET value from env and check
     max_offset = current_app.config["MAX_OFFSET"]
@@ -118,6 +118,18 @@ def get_reservations_for_book_id(book_id_str):
             jsonify(
                 {
                     "error": f"Offset has to be a positive number no greater than {max_offset}."
+                }
+            ),
+            400,
+        )
+    # Validate MAX_LIMIT
+    max_limit = current_app.config["MAX_LIMIT"]
+
+    if limit < 0 or limit > max_limit:
+        return (
+            jsonify(
+                {
+                    "error": f"Limit has to be a positive number no greater than {max_limit}."
                 }
             ),
             400,

--- a/app/routes/reservation_routes.py
+++ b/app/routes/reservation_routes.py
@@ -102,13 +102,6 @@ def get_reservations_for_book_id(book_id_str):
             400,
         )  # pylint: disable=line-too-long
 
-    # if limit < 0:
-    #     return (
-    #         jsonify(
-    #             {"error": "Query parameters 'limit' and 'offset' cannot be negative."}
-    #         ),
-    #         400,
-    #     )
     # Validate MAX_OFFSET
     # get the MAX_OFFSET value from env and check
     max_offset = current_app.config["MAX_OFFSET"]

--- a/openapi.yml
+++ b/openapi.yml
@@ -433,7 +433,7 @@ paths:
             format: int32
             default: 20
             minimum: 1
-            maximum: 100
+            maximum: 1000
             example: 10
       responses:
         '200':
@@ -654,7 +654,7 @@ paths:
             format: int32
             default: 20
             minimum: 1
-            maximum: 100
+            maximum: 1000
       responses:
         '200': 
           description: Successfully retrieved the list of reservations.

--- a/tests/test_pagination.py
+++ b/tests/test_pagination.py
@@ -28,6 +28,8 @@ def test_get_books_with_invalid_params(client, query_params, expected_error_msg)
 
 
 invalid_offset_values = [-1, 2001]
+
+
 @pytest.mark.parametrize("invalid_offset", invalid_offset_values)
 def test_get_books_fails_for_out_of_range_offset(client, invalid_offset):
     """
@@ -51,7 +53,10 @@ def test_get_books_fails_for_out_of_range_offset(client, invalid_offset):
     assert "error" in json_data
     assert json_data["error"] in expected_error_msg
 
+
 invalid_limit_values = [-1, 1001]
+
+
 @pytest.mark.parametrize("invalid_limit", invalid_limit_values)
 def test_get_books_fail_got_out_of_range_limit(client, invalid_limit):
     """

--- a/tests/test_pagination.py
+++ b/tests/test_pagination.py
@@ -9,7 +9,6 @@ import pytest
 @pytest.mark.parametrize(
     "query_params, expected_error_msg",
     [
-        ("?limit=-5", "cannot be negative"),
         ("?limit=abc", "must be integers"),
         ("?offset=abc", "must be integers"),
     ],

--- a/tests/test_pagination.py
+++ b/tests/test_pagination.py
@@ -58,14 +58,14 @@ invalid_limit_values = [-1, 1001]
 
 
 @pytest.mark.parametrize("invalid_limit", invalid_limit_values)
-def test_get_books_fail_got_out_of_range_limit(client, invalid_limit):
+def test_get_books_fails_for_out_of_range_limit(client, invalid_limit):
     """
     GIVEN an limit that is either negative or exceeds the configured max
-    WHEN a GET request is made to /books with that offset
+    WHEN a GET request is made to /books with that limit
     THEN it should return a 400 Bad Request with the correct error message.
     """
     # Arrange
-    # Get the max_offset from the app's config to build the expected message.
+    # Get the max_limit from the app's config to build the expected message.
     max_limit = client.application.config["MAX_LIMIT"]
     expected_error_msg = (
         f"Limit has to be a positive number no greater than {max_limit}."

--- a/tests/test_pagination.py
+++ b/tests/test_pagination.py
@@ -29,8 +29,6 @@ def test_get_books_with_invalid_params(client, query_params, expected_error_msg)
 
 
 invalid_offset_values = [-1, 2001]
-
-
 @pytest.mark.parametrize("invalid_offset", invalid_offset_values)
 def test_get_books_fails_for_out_of_range_offset(client, invalid_offset):
     """
@@ -47,6 +45,30 @@ def test_get_books_fails_for_out_of_range_offset(client, invalid_offset):
 
     # Act
     response = client.get(f"/books?offset={invalid_offset}")
+    json_data = response.get_json()
+
+    # Assert
+    assert response.status_code == 400
+    assert "error" in json_data
+    assert json_data["error"] in expected_error_msg
+
+invalid_limit_values = [-1, 1001]
+@pytest.mark.parametrize("invalid_limit", invalid_limit_values)
+def test_get_books_fail_got_out_of_range_limit(client, invalid_limit):
+    """
+    GIVEN an limit that is either negative or exceeds the configured max
+    WHEN a GET request is made to /books with that offset
+    THEN it should return a 400 Bad Request with the correct error message.
+    """
+    # Arrange
+    # Get the max_offset from the app's config to build the expected message.
+    max_limit = client.application.config["MAX_LIMIT"]
+    expected_error_msg = (
+        f"Limit has to be a positive number no greater than {max_limit}."
+    )
+
+    # Act
+    response = client.get(f"/books?limit={invalid_limit}")
     json_data = response.get_json()
 
     # Assert

--- a/tests/test_reservations.py
+++ b/tests/test_reservations.py
@@ -391,6 +391,7 @@ def test_get_reservations_with_invalid_params(
 
 invalid_offset_values = [-1, 2001]
 
+
 @pytest.mark.parametrize("invalid_offset", invalid_offset_values)
 def test_get_reservations_fails_for_out_of_range_offset(
     client, seeded_books_in_db, admin_token, invalid_offset
@@ -422,7 +423,10 @@ def test_get_reservations_fails_for_out_of_range_offset(
     assert "error" in json_data
     assert json_data["error"] in expected_error_msg
 
+
 invalid_limit_values = [-1, 1001]
+
+
 @pytest.mark.parametrize("invalid_limit", invalid_limit_values)
 def test_get_reservations_fails_for_out_of_range_limit(
     client, seeded_books_in_db, admin_token, invalid_limit

--- a/tests/test_reservations.py
+++ b/tests/test_reservations.py
@@ -392,20 +392,19 @@ def test_get_reservations_with_invalid_params(
 
 invalid_offset_values = [-1, 2001]
 
-
 @pytest.mark.parametrize("invalid_offset", invalid_offset_values)
 def test_get_reservations_fails_for_out_of_range_offset(
     client, seeded_books_in_db, admin_token, invalid_offset
-):  # pylint: disable=line-too-long
+):
     """
     GIVEN an offset that is either negative or exceeds the configured max
-    WHEN a GET request is made to /books/{id}/endpoint with that offset
+    WHEN a GET request is made to /books/{id}/reservations endpoint with that offset
     THEN it should return a 400 Bad Request with the correct error message.
     """
     # ARRANGE: Get a valid book ID from our seeded data
     book_id_str = seeded_books_in_db[0]["_id"]
     auth_headers = {"Authorization": f"Bearer {admin_token}"}
-    # Arrange
+
     # Get the max_offset from the app's config to build the expected message.
     max_offset = client.application.config["MAX_OFFSET"]
     expected_error_msg = (
@@ -415,6 +414,37 @@ def test_get_reservations_fails_for_out_of_range_offset(
     # Act
     response = client.get(
         f"/books/{book_id_str}/reservations?offset={invalid_offset}",
+        headers=auth_headers,
+    )
+    json_data = response.get_json()
+
+    # Assert
+    assert response.status_code == 400
+    assert "error" in json_data
+    assert json_data["error"] in expected_error_msg
+
+invalid_limit_values = [-1, 1001]
+@pytest.mark.parametrize("invalid_limit", invalid_limit_values)
+def test_get_reservations_fails_for_out_of_range_limit(
+    client, seeded_books_in_db, admin_token, invalid_limit
+):
+    """
+    GIVEN an limit that is either negative or exceeds the configured max
+    WHEN a GET request is made to /books/{id}/reservations endpoint with that offset
+    THEN it should return a 400 Bad Request with the correct error message.
+    """
+    # ARRANGE: Get a valid book ID from our seeded data
+    book_id_str = seeded_books_in_db[0]["_id"]
+    auth_headers = {"Authorization": f"Bearer {admin_token}"}
+
+    # Get the max_offset from the app's config to build the expected message.
+    max_limit = client.application.config["MAX_LIMIT"]
+    expected_error_msg = (
+        f"Limit has to be a positive number no greater than {max_limit}."
+    )
+    # Act
+    response = client.get(
+        f"/books/{book_id_str}/reservations?offset={invalid_limit}",
         headers=auth_headers,
     )
     json_data = response.get_json()

--- a/tests/test_reservations.py
+++ b/tests/test_reservations.py
@@ -444,7 +444,7 @@ def test_get_reservations_fails_for_out_of_range_limit(
     )
     # Act
     response = client.get(
-        f"/books/{book_id_str}/reservations?offset={invalid_limit}",
+        f"/books/{book_id_str}/reservations?limit={invalid_limit}",
         headers=auth_headers,
     )
     json_data = response.get_json()

--- a/tests/test_reservations.py
+++ b/tests/test_reservations.py
@@ -361,7 +361,6 @@ def test_get_reservations_skips_reservation_with_nonexistent_user(
 @pytest.mark.parametrize(
     "query_params, expected_error_msg",
     [
-        ("?limit=-5", "cannot be negative"),
         ("?limit=abc", "must be integers"),
         ("?offset=xyz", "must be integers"),
     ],

--- a/tests/test_reservations.py
+++ b/tests/test_reservations.py
@@ -432,15 +432,15 @@ def test_get_reservations_fails_for_out_of_range_limit(
     client, seeded_books_in_db, admin_token, invalid_limit
 ):
     """
-    GIVEN an limit that is either negative or exceeds the configured max
-    WHEN a GET request is made to /books/{id}/reservations endpoint with that offset
+    GIVEN a limit that is either negative or exceeds the configured max
+    WHEN a GET request is made to /books/{id}/reservations endpoint with that limit
     THEN it should return a 400 Bad Request with the correct error message.
     """
     # ARRANGE: Get a valid book ID from our seeded data
     book_id_str = seeded_books_in_db[0]["_id"]
     auth_headers = {"Authorization": f"Bearer {admin_token}"}
 
-    # Get the max_offset from the app's config to build the expected message.
+    # Get the max_limit from the app's config to build the expected message.
     max_limit = client.application.config["MAX_LIMIT"]
     expected_error_msg = (
         f"Limit has to be a positive number no greater than {max_limit}."


### PR DESCRIPTION
## Description

Trello card: https://trello.com/c/qQKDXluX
This PR introduces a configurable maximum offset value for pagination across reservation endpoints.
- Adds a MAX_LIMIT environment variable with a fallback default of 1000.
- Ensures offsets cannot exceed this maximum; otherwise, a validation error is raised.
- Default limit remains 20 for normal pagination use.
- Cleans up redundant offset validation logic and tests.


## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)


## How Has This Been Tested?
- Added unit tests for invalid limit values (negative, above max).
- Updated reservation service and controller tests to validate new logic.
- Verified default behavior when no MAX_LIMIT is provided.
- Ran full test suite – all tests passing.


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] **My individual commit messages are descriptive and follow our [commit guidelines](https://martijnhols.nl/blog/how-to-write-a-good-git-commit-message/)**
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

